### PR TITLE
Name scheme

### DIFF
--- a/librato/__init__.py
+++ b/librato/__init__.py
@@ -169,9 +169,9 @@ class LibratoConnection(object):
     resp = self._mexe("metrics", query_props=query_props)
     return self._parse(resp, "metrics", Metric)
 
-  def submit(self, name, value, type="gauge", **query_props):
+  def submit(self, metric_name, value, type="gauge", **query_props):
     payload = {'gauges': [], 'counters': []}
-    metric = { 'name': name, 'value': value }
+    metric = { 'name': metric_name, 'value': value }
     for k,v in query_props.items():
       metric[k] = v
     payload[type + 's'].append(metric)


### PR DESCRIPTION
For queueing requests I often use `api.submit(**data)` or if the data is a tuple then 

``` python
q = api.new_queue()
[q.add(**r) for r in data]
q.submit()
```

which throws errors due to argument name is different
