### PR TITLE
Fix str exception raised in LibratoConnection

### DIFF
--- a/librato/__init__.py
+++ b/librato/__init__.py
@@ -75,7 +75,7 @@ class LibratoConnection(object):
             self.username = username.encode('ascii')
             self.api_key = api_key.encode('ascii')
         except:
-            raise("Librato only supports ascii for the credentials")
+            raise TypeError("Librato only supports ascii for the credentials")
 
         self.hostname = hostname
         self.base_path = base_path


### PR DESCRIPTION
When librato connection is None for example, the `__init__` method of the LibratoConnection object raises an "str" exception.

It leads the python interpreter to throw an exception:

``` python
/mysupperdupperenv/lib/python2.7/site-packages/librato/__init__.pyc in __init__(self, username, api_key, hostname, base_path)
     73       self.api_key   = api_key.encode('ascii')
     74     except:
---> 75       raise("Librato only supports ascii for the credentials")
     76
     77     self.hostname      = hostname

TypeError: exceptions must be old-style classes or derived from BaseException, not str
```

This fix leads `__init__` method to throw a _TypeError_ instead.
