### PR TITLE
Submitting an empty queue causes a request error

### DIFF
--- a/librato/queue.py
+++ b/librato/queue.py
@@ -56,9 +56,12 @@ class Queue(object):
         self._add_measurement(type, nm)
 
     def submit(self):
+        empty_chunks = [self._gen_empty_chunk()]
+        if self.chunks == empty_chunks:
+            return
         for c in self.chunks:
             self.connection._mexe("metrics", method="POST", query_props=c)
-        self.chunks = [self._gen_empty_chunk()]
+        self.chunks = empty_chunks
 
     # Private, sort of.
     #

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -21,7 +21,6 @@
 
 import logging
 import nose
-import time
 import librato
 import os
 from random import randint
@@ -97,6 +96,9 @@ class TestLibratoBasic(object):
             q.add('temperature', randint(20, 30), source='downstairs', measure_time=time.time()+t)
         q.submit()
         self.conn.delete('temperature')
+
+    def test_submit_empty_queue(self):
+        self.conn.new_queue().submit()
 
     def test_send_batch_counter_measurements(self):
         q = self.conn.new_queue()


### PR DESCRIPTION
I don't know if this is intentional or not. If it is not then this PR makes it so submitting an empty queue is essentially a no-op.

If it is intentional perhaps a local exception can be thrown instead of making an api call?
