### PR TITLE
Fixed bug in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ that autosubmits based on metric volume.
 ```python
 api = librato.connect(user, token)
 # Submit when the 400th metric is queued
-q = api.new_queue(auto_submit=400)
+q = api.new_queue(auto_submit_count=400)
 ```
 
 ## Updating Metrics


### PR DESCRIPTION
The argument in the docs is mildly incorrect. It should be auto_submit_count not auto_submit. See https://github.com/librato/python-librato/blob/master/librato/queue.py 
