### PR TITLE
Fix add method in Gauge and Counter metrics classes

### DIFF
--- a/librato/__init__.py
+++ b/librato/__init__.py
@@ -189,7 +189,7 @@ class LibratoConnection(object):
         if resp['type'] == 'gauge':
             return Gauge.from_dict(self, resp)
         elif resp['type'] == 'counter':
-            return Gauge.from_dict(self, resp)
+            return Counter.from_dict(self, resp)
         else:
             raise Exception('The server sent me something that is not a Gauge nor a Counter.')
 

--- a/librato/metrics.py
+++ b/librato/metrics.py
@@ -68,7 +68,9 @@ class Gauge(Metric):
     """Librato Gauge metric"""
     def add(self, value, source=None, **params):
         """Add a new measurement to this gauge"""
-        return self.connection.send_gauge_value(self.name, value, source, **params)
+        if source:
+            params['source'] = source
+        return self.connection.submit(self.name, value, type="gauge", **params)
 
     def what_am_i(self):
         return 'gauges'
@@ -77,7 +79,10 @@ class Gauge(Metric):
 class Counter(Metric):
     """Librato Counter metric"""
     def add(self, value, source=None, **params):
-        return self.connection.send_counter_value(self.name, value, source, **params)
+        if source:
+            params['source'] = source
+
+        return self.connection.submit(self.name, value, type="counter", **params)
 
     def what_am_i(self):
         return 'counters'

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -118,5 +118,41 @@ class TestLibrato(unittest.TestCase):
         assert len(counter.measurements[src]) == 1
         assert counter.measurements[src][0]['value'] == 111
 
+    def test_add_in_counter(self):
+        name, desc, src = 'Test', 'A Test Counter.', 'from_source'
+        self.conn.submit(name, 111, type='counter', description=desc, source=src)
+        counter = self.conn.get(name)
+        assert counter.name == name
+        assert counter.description == desc
+        assert len(counter.measurements[src]) == 1
+        assert counter.measurements[src][0]['value'] == 111
+
+        counter.add(1, source=src)
+
+        counter = self.conn.get(name)
+        assert counter.name == name
+        assert counter.description == desc
+        assert len(counter.measurements[src]) == 2
+        assert counter.measurements[src][-1]['value'] == 1
+
+    def test_add_in_gauge(self):
+        name, desc, src = 'Test', 'A Test Gauge.', 'from_source'
+        self.conn.submit(name, 10, description=desc, source=src)
+        gauge = self.conn.get(name)
+        assert gauge.name == name
+        assert gauge.description == desc
+        assert len(gauge.measurements[src]) == 1
+        assert gauge.measurements[src][0]['value'] == 10
+
+        gauge.add(1, source=src)
+
+        gauge = self.conn.get(name)
+        assert gauge.name == name
+        assert gauge.description == desc
+        assert len(gauge.measurements[src]) == 2
+        assert gauge.measurements[src][-1]['value'] == 1
+
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The add method in Gauge and Counter classes used some outdated method from LibratoConnection class
