### PR TITLE
Use one dash to replace multiple bad characters

### DIFF
--- a/librato/__init__.py
+++ b/librato/__init__.py
@@ -59,7 +59,7 @@ except AttributeError:
 
 
 def sanitize_metric_name(metric_name):
-    disallowed_character_pattern = r"([^A-Za-z0-9.:\-_]|[\[\]]|\s)"
+    disallowed_character_pattern = r"(([^A-Za-z0-9.:\-_]|[\[\]]|\s)+)"
     max_metric_name_length = 255
     return re.sub(disallowed_character_pattern, '-', metric_name)[:max_metric_name_length]
 

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -14,6 +14,7 @@ class TestSanitization(unittest.TestCase):
             (valid_chars, valid_chars),
             (valid_chars.upper(), valid_chars.upper()),
             ('a'*500, 'a'*255),
-            ('   \t\nbat$$$*[]()m#@%^&=`~an', '-----bat--------m--------an')  # throw in a unicode char
+            ('   \t\nbat$$$*[]()m#@%^&=`~an', '-bat-m-an'),  # throw in a unicode char
+            ('Just*toBeSafe', 'Just-toBeSafe')
         ]:
             self.assertEquals(sanitize_metric_name(name), expected)


### PR DESCRIPTION
Looking at the end of this PR https://github.com/librato/python-librato/pull/70

@twall made some good points. This PR adopts his idea by replacing the regex the sanitizer was using with a greedy version of it.
