### PR TITLE
Allow Instrument#save to create a new instrument

### DIFF
--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -44,7 +44,7 @@ class Instrument(object):
         return self.id is not None
 
     def save(self):
-        if self.is_persisted():
+        if not self.is_persisted():
             dummy_inst = self.connection.create_instrument(
                     self.name,
                     attributes=self.attributes,

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -30,15 +30,28 @@ class Instrument(object):
     def get_payload(self):
         return {'name': self.name,
                 'attributes': self.attributes,
-                'streams': [x.get_payload() for x in self.streams]}
+                'streams': self.streams_payload()}
 
     def new_stream(self, metric=None, source='*', composite=None):
         stream = Stream(metric, source, composite)
         self.streams.append(stream)
         return stream
 
+    def streams_payload(self):
+        return [s.get_payload() for s in self.streams]
+
+    def is_persisted(self):
+        return self.id is not None
+
     def save(self):
-        self.connection.update_instrument(self)
+        if self.is_persisted():
+            dummy_inst = self.connection.create_instrument(
+                    self.name,
+                    attributes=self.attributes,
+                    streams=self.streams_payload())
+            self.id = dummy_inst.id
+        else:
+            self.connection.update_instrument(self)
 
 
 class Stream(object):

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -207,6 +207,22 @@ class TestLibratoBasic(unittest.TestCase):
         assert len(ins.streams) == 1
         assert ins.streams[0].composite == 's("cpu", "*")'
 
+    def test_instrument_save_creates_new_record(self):
+        instrument_name = 'my instrument name'
+        i = librato.Instrument(self.conn, instrument_name)
+        assert i.id is None
+        i.save()
+        assert i.name == instrument_name
+
+    def test_instrument_save_updates_existing_record(self):
+        instrument_name = 'my instrument name'
+        i = self.conn.create_instrument(instrument_name)
+        assert i.name == instrument_name
+        i.name = 'NEW instrument name'
+        i.save()
+        i = self.conn.get_instrument(i.id)
+        assert i.name == 'NEW instrument name'
+
 if __name__ == '__main__':
     # TO run a specific test:
     # $ nosetests tests/integration.py:TestLibratoBasic.test_update_metrics_attributes

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -74,5 +74,11 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.id == 1
         assert ins.streams[0].composite == "my_composite_string_with_no_validation"
 
+    def test_is_persisted(self):
+        i = librato.Instrument(self.conn, 'test inst')
+        assert i.is_persisted() == False
+        i = librato.Instrument(self.conn, 'test inst', id=1234)
+        assert i.is_persisted() == True
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously, calling `Instrument#save` only allowed for updating an existing instrument instance.  This adds the capability to create a new instrument via:

```python
i = Instrument(conn, 'my instrument name')
i.save()
```
Whether the instrument is created or updated depends on the presence of the `id` attribute.