### PR TITLE
Add basic GET support for composite metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,25 @@ To retrieve a specific metric:
   counter = api.get("connections")
 ```
 
+To retrieve a composite metric:
+
+```python
+  # Get average temperature in all cities for last 8 hours
+  compose = 'mean(s("temperature", "*", {function: "mean", period: "3600"}))'
+  start_time = int(time.time()) - 8 * 3600
+  resp = api.get_composite(compose, start_time=start_time)
+  resp['measurements'][0]['series']
+  # [
+  #   {u'measure_time': 1421744400, u'value': 41.23944444444444},
+  #   {u'measure_time': 1421748000, u'value': 40.07611111111111},
+  #   {u'measure_time': 1421751600, u'value': 38.77444444444445},
+  #   {u'measure_time': 1421755200, u'value': 38.05833333333333},
+  #   {u'measure_time': 1421758800, u'value': 37.983333333333334},
+  #   {u'measure_time': 1421762400, u'value': 38.93333333333333},
+  #   {u'measure_time': 1421766000, u'value': 40.556666666666665}
+  # ]
+```
+
 For sending more measurements:
 
 ```python

--- a/librato/__init__.py
+++ b/librato/__init__.py
@@ -212,6 +212,12 @@ class LibratoConnection(object):
         else:
             raise Exception('The server sent me something that is not a Gauge nor a Counter.')
 
+    def get_composite(self, compose, **query_props):
+        if 'start_time' not in query_props or 'resolution' not in query_props:
+            raise Exception("You must provide a 'start_time' and a 'resolution'")
+        query_props['compose'] = compose
+        return self._mexe("metrics", method="GET", query_props=query_props)
+
     def update(self, name, **query_props):
         resp = self._mexe("metrics/%s" % self.sanitize(name), method="PUT", query_props=query_props)
 

--- a/librato/__init__.py
+++ b/librato/__init__.py
@@ -213,8 +213,11 @@ class LibratoConnection(object):
             raise Exception('The server sent me something that is not a Gauge nor a Counter.')
 
     def get_composite(self, compose, **query_props):
-        if 'start_time' not in query_props or 'resolution' not in query_props:
-            raise Exception("You must provide a 'start_time' and a 'resolution'")
+        if 'resolution' not in query_props:
+            # Default to raw resolution
+            query_props['resolution'] = 1
+        if 'start_time' not in query_props:
+            raise Exception("You must provide a 'start_time'")
         query_props['compose'] = compose
         return self._mexe("metrics", method="GET", query_props=query_props)
 


### PR DESCRIPTION
This adds a `get_composite()` method to the `LibratoConnection` class which returns a `dict` containing the composite response.  This is impemented in a manner similar to https://github.com/librato/librato-metrics/pull/103 and does not attempt to formalize composites into an object-oriented structure.  Rather, we're just returning the hash of values from the API response.

Fixes #57 