### PR TITLE
Improvements / bugfixes before releasing Alerts

### DIFF
--- a/tests/integration.py
+++ b/tests/integration.py
@@ -228,11 +228,18 @@ class TestLibratoBasic(TestLibratoBase):
 class TestLibratoAlertsIntegration(TestLibratoBase):
 
     alerts_created_during_test=[]
+    gauges_used_during_test = ['metric_test', 'cpu']
+
+    def setUp(self):
+        # Ensure metric names exist so we can create conditions on them
+        for m in self.gauges_used_during_test:
+            # Create or just update a gauge metric
+            self.conn.submit(m, 42)
 
     def tearDown(self):
         for name in self.alerts_created_during_test:
             self.conn.delete_alert(name)
-    
+
     def test_add_empty_alert(self):
         name = self.unique_name("test_add_empty_alert")
         alert = self.conn.create_alert(name)

--- a/tests/mock_connection.py
+++ b/tests/mock_connection.py
@@ -92,13 +92,14 @@ class MockServer(object):
                             " exists %d", _id)
         else:
             return json.dumps(self.instruments[int(_id)]).encode('utf-8')
-    
+
     def __an_empty_list_metrics(self):
         answer = {}
 
     def create_alert(self, payload):
         self.last_a_id += 1
         payload["id"] = self.last_a_id
+        payload["active"] = True
         self.alerts[self.last_a_id] = payload
         return json.dumps(payload).encode('utf-8')
 

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -77,7 +77,7 @@ class TestLibratoAlerts(unittest.TestCase):
         assert condition.metric_name == 'metric_test'
         assert condition.threshold == 200
         assert condition._duration == 5
-    
+
     def test_add_absent_condition(self):
         alert = self.conn.create_alert(self.name)
         alert.add_condition_for('metric_test').stops_reporting_for(5)
@@ -86,6 +86,20 @@ class TestLibratoAlerts(unittest.TestCase):
         assert condition.condition_type == 'absent'
         assert condition.metric_name == 'metric_test'
         assert condition._duration == 5
+
+    def test_immediate_condition(self):
+        cond = librato.alerts.Condition('foo')
+
+        cond._duration = None
+        assert cond.immediate() == True
+
+        # Not even sure this is a valid case, but testing anyway
+        cond._duration = 0
+        assert cond.immediate() == True
+
+        cond._duration = 60
+        assert cond.immediate() == False
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Making a few enhancements before releasing alert support into the wild

* Fixed some comments
* Removed some whitespace
* Hydrate `active` flag when loading an `Alert`
* Added `immediate()` instance method to `Condition` model for convenience / interrogation
* `list_alerts()` defaults to only show active alerts
* Fix issue in integration test where 400s come back because metric names might not exist
* Attempt to use constants for some hardcoded attribute names
* `delete_alert()` doesn't need any `query_props` so removed those

@mauricioborges I've made a few tweaks and a bug fix or two after #76 and plan to release this tomorrow unless you see any blockers, thanks!