### PR TITLE
Add more stream properties to new_stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,38 @@ alert.add_condition_for('metric_name').stops_reporting_for(1) # duration of the 
 alert.save()
 ```
 
+## Instruments
+
+Create a new instrument with a composite:
+
+```python
+ins = api.create_instrument(name='CPU instrument')
+ins.new_stream(composite='s("cpu", "*")', name='CPU',
+    units_short='%', units_long='percentage',
+    display_min=0, display_max=100, summary_function='average',
+    transform_function='x/1', period=60, color='#52D74C')
+ins.attributes = {
+    'display_integral': False,
+    'display_stacked': False
+}
+api.update_instrument(ins)
+```
+
+Create a new instrument with a metric:
+
+```python
+ins = api.create_instrument(name='CPU instrument')
+ins.new_stream(metric='cpu', name='CPU', source='*',
+    units_short='%', units_long='percentage',
+    display_min=0, display_max=100, summary_function='average',
+    transform_function='x/1', period=60, color='#52D74C',
+    group_function='average')
+ins.attributes = {
+    'display_integral': False,
+    'display_stacked': False
+}
+api.update_instrument(ins)
+```
 ## Misc
 
 ### Timeouts

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -11,9 +11,9 @@ class Instrument(object):
                 self.streams.append(i)
             elif isinstance(i, dict):  # Probably parsing JSON here
                 stream = Stream(i.get('metric'), i.get('source'), i.get('composite'),
-                        i.get('units_short'), i.get('units_long'), i.get('min'), i.get('max'),
-                        i.get('summary_function'), i.get('transform_function'),
-                        i.get('period'))
+                        i.get('name'), i.get('units_short'), i.get('units_long'),
+                        i.get('min'), i.get('max'), i.get('summary_function'),
+                        i.get('transform_function'), i.get('period'))
                 self.streams.append(stream)
             else:
                 self.streams.append(Stream(*i))
@@ -36,10 +36,10 @@ class Instrument(object):
                 'attributes': self.attributes,
                 'streams': self.streams_payload()}
 
-    def new_stream(self, metric=None, source='*', composite=None,
+    def new_stream(self, metric=None, source='*', composite=None, name=None,
             units_short=None, units_long=None, display_min=None, display_max=None,
             summary_function='average', transform_function=None, period=None):
-        stream = Stream(metric, source, composite,
+        stream = Stream(metric, source, composite, name,
                units_short, units_long, display_min, display_max,
                summary_function, transform_function, period)
         self.streams.append(stream)
@@ -63,12 +63,13 @@ class Instrument(object):
 
 
 class Stream(object):
-    def __init__(self, metric=None, source='*', composite=None,
+    def __init__(self, metric=None, source='*', composite=None, name=None,
             units_short=None, units_long=None, display_min=None, display_max=None,
             summary_function='average', transform_function=None, period=None):
         self.metric = metric
         self.composite = composite
         self.source = source
+        self.name = name
         self.units_short = units_short
         self.units_long = units_long
         self.display_min = display_min
@@ -83,6 +84,7 @@ class Stream(object):
         return {'metric': self.metric,
                 'composite': self.composite,
                 'source': self.source,
+                'name': self.name,
                 'units_short': self.units_short,
                 'units_long': self.units_long,
                 'min': self.display_min,

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -14,7 +14,7 @@ class Instrument(object):
                         i.get('name'), i.get('units_short'), i.get('units_long'),
                         i.get('min'), i.get('max'), i.get('summary_function'),
                         i.get('transform_function'), i.get('period'),
-                        i.get('group_function'))
+                        i.get('group_function'), i.get('color'))
                 self.streams.append(stream)
             else:
                 self.streams.append(Stream(*i))
@@ -40,10 +40,11 @@ class Instrument(object):
     def new_stream(self, metric=None, source='*', composite=None, name=None,
             units_short=None, units_long=None, display_min=None, display_max=None,
             summary_function='average', transform_function=None, period=None,
-            group_function='average'):
+            group_function='average', color=None):
         stream = Stream(metric, source, composite, name,
                units_short, units_long, display_min, display_max,
-               summary_function, transform_function, period, group_function)
+               summary_function, transform_function, period,
+               group_function, color)
         self.streams.append(stream)
         return stream
 
@@ -68,7 +69,7 @@ class Stream(object):
     def __init__(self, metric=None, source='*', composite=None, name=None,
             units_short=None, units_long=None, display_min=None, display_max=None,
             summary_function='average', transform_function=None, period=None,
-            group_function='average'):
+            group_function='average', color=None):
         self.metric = metric
         self.composite = composite
         self.source = source
@@ -81,6 +82,7 @@ class Stream(object):
         self.transform_function = transform_function
         self.period = period
         self.group_function = group_function
+        self.color = color
 
         if self.composite:
             self.source = None
@@ -98,4 +100,5 @@ class Stream(object):
                 'summary_function': self.summary_function,
                 'transform_function': self.transform_function,
                 'period': self.period,
-                'group_function': self.group_function}
+                'group_function': self.group_function,
+                'color': self.color}

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -13,7 +13,8 @@ class Instrument(object):
                 stream = Stream(i.get('metric'), i.get('source'), i.get('composite'),
                         i.get('name'), i.get('units_short'), i.get('units_long'),
                         i.get('min'), i.get('max'), i.get('summary_function'),
-                        i.get('transform_function'), i.get('period'))
+                        i.get('transform_function'), i.get('period'),
+                        i.get('group_function'))
                 self.streams.append(stream)
             else:
                 self.streams.append(Stream(*i))
@@ -38,10 +39,11 @@ class Instrument(object):
 
     def new_stream(self, metric=None, source='*', composite=None, name=None,
             units_short=None, units_long=None, display_min=None, display_max=None,
-            summary_function='average', transform_function=None, period=None):
+            summary_function='average', transform_function=None, period=None,
+            group_function='average'):
         stream = Stream(metric, source, composite, name,
                units_short, units_long, display_min, display_max,
-               summary_function, transform_function, period)
+               summary_function, transform_function, period, group_function)
         self.streams.append(stream)
         return stream
 
@@ -65,7 +67,8 @@ class Instrument(object):
 class Stream(object):
     def __init__(self, metric=None, source='*', composite=None, name=None,
             units_short=None, units_long=None, display_min=None, display_max=None,
-            summary_function='average', transform_function=None, period=None):
+            summary_function='average', transform_function=None, period=None,
+            group_function='average'):
         self.metric = metric
         self.composite = composite
         self.source = source
@@ -77,8 +80,11 @@ class Stream(object):
         self.summary_function = summary_function
         self.transform_function = transform_function
         self.period = period
+        self.group_function = group_function
+
         if self.composite:
             self.source = None
+            self.group_function = None
 
     def get_payload(self):
         return {'metric': self.metric,
@@ -91,4 +97,5 @@ class Stream(object):
                 'max': self.display_max,
                 'summary_function': self.summary_function,
                 'transform_function': self.transform_function,
-                'period': self.period}
+                'period': self.period,
+                'group_function': self.group_function}

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -11,7 +11,8 @@ class Instrument(object):
                 self.streams.append(i)
             elif isinstance(i, dict):  # Probably parsing JSON here
                 stream = Stream(i.get('metric'), i.get('source'), i.get('composite'),
-                        i.get('units_short'), i.get('units_long'), i.get('min'), i.get('max'), i.get('summary_function'))
+                        i.get('units_short'), i.get('units_long'), i.get('min'), i.get('max'),
+                        i.get('summary_function'), i.get('transform_function'))
                 self.streams.append(stream)
             else:
                 self.streams.append(Stream(*i))
@@ -35,9 +36,11 @@ class Instrument(object):
                 'streams': self.streams_payload()}
 
     def new_stream(self, metric=None, source='*', composite=None,
-            units_short=None, units_long=None, display_min=None, display_max=None, summary_function='average'):
+            units_short=None, units_long=None, display_min=None, display_max=None,
+            summary_function='average', transform_function=None):
         stream = Stream(metric, source, composite,
-               units_short, units_long, display_min, display_max, summary_function)
+               units_short, units_long, display_min, display_max,
+               summary_function, transform_function)
         self.streams.append(stream)
         return stream
 
@@ -60,7 +63,8 @@ class Instrument(object):
 
 class Stream(object):
     def __init__(self, metric=None, source='*', composite=None,
-            units_short=None, units_long=None, display_min=None, display_max=None, summary_function='average'):
+            units_short=None, units_long=None, display_min=None, display_max=None,
+            summary_function='average', transform_function=None):
         self.metric = metric
         self.composite = composite
         self.source = source
@@ -69,6 +73,7 @@ class Stream(object):
         self.display_min = display_min
         self.display_max = display_max
         self.summary_function = summary_function
+        self.transform_function = transform_function
         if self.composite:
             self.source = None
 
@@ -80,4 +85,5 @@ class Stream(object):
                 'units_long': self.units_long,
                 'min': self.display_min,
                 'max': self.display_max,
-                'summary_function': self.summary_function}
+                'summary_function': self.summary_function,
+                'transform_function': self.transform_function}

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -10,7 +10,9 @@ class Instrument(object):
             if isinstance(i, Stream):
                 self.streams.append(i)
             elif isinstance(i, dict):  # Probably parsing JSON here
-                self.streams.append(Stream(i.get('metric'), i.get('source'), i.get('composite'), i.get('units_short')))
+                stream = Stream(i.get('metric'), i.get('source'), i.get('composite'),
+                        i.get('units_short'), i.get('units_long'))
+                self.streams.append(stream)
             else:
                 self.streams.append(Stream(*i))
         self.attributes = attributes
@@ -32,8 +34,9 @@ class Instrument(object):
                 'attributes': self.attributes,
                 'streams': self.streams_payload()}
 
-    def new_stream(self, metric=None, source='*', composite=None, units_short=None):
-        stream = Stream(metric, source, composite, units_short)
+    def new_stream(self, metric=None, source='*', composite=None,
+            units_short=None, units_long=None):
+        stream = Stream(metric, source, composite, units_short, units_long)
         self.streams.append(stream)
         return stream
 
@@ -55,11 +58,13 @@ class Instrument(object):
 
 
 class Stream(object):
-    def __init__(self, metric=None, source='*', composite=None, units_short=None):
+    def __init__(self, metric=None, source='*', composite=None,
+            units_short=None, units_long=None):
         self.metric = metric
         self.composite = composite
         self.source = source
         self.units_short = units_short
+        self.units_long = units_long
         if self.composite:
             self.source = None
 
@@ -67,4 +72,5 @@ class Stream(object):
         return {'metric': self.metric,
                 'composite': self.composite,
                 'source': self.source,
-                'units_short': self.units_short}
+                'units_short': self.units_short,
+                'units_long': self.units_long}

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -11,7 +11,7 @@ class Instrument(object):
                 self.streams.append(i)
             elif isinstance(i, dict):  # Probably parsing JSON here
                 stream = Stream(i.get('metric'), i.get('source'), i.get('composite'),
-                        i.get('units_short'), i.get('units_long'))
+                        i.get('units_short'), i.get('units_long'), i.get('min'))
                 self.streams.append(stream)
             else:
                 self.streams.append(Stream(*i))
@@ -35,8 +35,8 @@ class Instrument(object):
                 'streams': self.streams_payload()}
 
     def new_stream(self, metric=None, source='*', composite=None,
-            units_short=None, units_long=None):
-        stream = Stream(metric, source, composite, units_short, units_long)
+            units_short=None, units_long=None, display_min=None):
+        stream = Stream(metric, source, composite, units_short, units_long, display_min)
         self.streams.append(stream)
         return stream
 
@@ -59,12 +59,13 @@ class Instrument(object):
 
 class Stream(object):
     def __init__(self, metric=None, source='*', composite=None,
-            units_short=None, units_long=None):
+            units_short=None, units_long=None, display_min=None):
         self.metric = metric
         self.composite = composite
         self.source = source
         self.units_short = units_short
         self.units_long = units_long
+        self.display_min = display_min
         if self.composite:
             self.source = None
 
@@ -73,4 +74,5 @@ class Stream(object):
                 'composite': self.composite,
                 'source': self.source,
                 'units_short': self.units_short,
-                'units_long': self.units_long}
+                'units_long': self.units_long,
+                'min': self.display_min}

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -10,12 +10,7 @@ class Instrument(object):
             if isinstance(i, Stream):
                 self.streams.append(i)
             elif isinstance(i, dict):  # Probably parsing JSON here
-                stream = Stream(i.get('metric'), i.get('source'), i.get('composite'),
-                        i.get('name'), i.get('units_short'), i.get('units_long'),
-                        i.get('min'), i.get('max'), i.get('summary_function'),
-                        i.get('transform_function'), i.get('period'),
-                        i.get('group_function'), i.get('color'))
-                self.streams.append(stream)
+                self.streams.append(Stream.from_dict(i))
             else:
                 self.streams.append(Stream(*i))
         self.attributes = attributes
@@ -37,14 +32,8 @@ class Instrument(object):
                 'attributes': self.attributes,
                 'streams': self.streams_payload()}
 
-    def new_stream(self, metric=None, source='*', composite=None, name=None,
-            units_short=None, units_long=None, display_min=None, display_max=None,
-            summary_function='average', transform_function=None, period=None,
-            group_function='average', color=None):
-        stream = Stream(metric, source, composite, name,
-               units_short, units_long, display_min, display_max,
-               summary_function, transform_function, period,
-               group_function, color)
+    def new_stream(self, *args, **kwargs):
+        stream = Stream(*args, **kwargs)
         self.streams.append(stream)
         return stream
 
@@ -87,6 +76,18 @@ class Stream(object):
         if self.composite:
             self.source = None
             self.group_function = None
+
+    @classmethod
+    def from_dict(cls, data):
+        """Returns a instrument object from a dictionary item,
+        which is usually from librato's API"""
+
+        obj = cls(data.get('metric'), data.get('source'), data.get('composite'),
+            data.get('name'), data.get('units_short'), data.get('units_long'),
+            data.get('min'), data.get('max'), data.get('summary_function'),
+            data.get('transform_function'), data.get('period'),
+            data.get('group_function'), data.get('color'))
+        return obj
 
     def get_payload(self):
         return {'metric': self.metric,

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -10,7 +10,7 @@ class Instrument(object):
             if isinstance(i, Stream):
                 self.streams.append(i)
             elif isinstance(i, dict):  # Probably parsing JSON here
-                self.streams.append(Stream(i.get('metric'), i.get('source'), i.get('composite')))
+                self.streams.append(Stream(i.get('metric'), i.get('source'), i.get('composite'), i.get('units_short')))
             else:
                 self.streams.append(Stream(*i))
         self.attributes = attributes
@@ -32,8 +32,8 @@ class Instrument(object):
                 'attributes': self.attributes,
                 'streams': self.streams_payload()}
 
-    def new_stream(self, metric=None, source='*', composite=None):
-        stream = Stream(metric, source, composite)
+    def new_stream(self, metric=None, source='*', composite=None, units_short=None):
+        stream = Stream(metric, source, composite, units_short)
         self.streams.append(stream)
         return stream
 
@@ -55,14 +55,16 @@ class Instrument(object):
 
 
 class Stream(object):
-    def __init__(self, metric=None, source='*', composite=None):
+    def __init__(self, metric=None, source='*', composite=None, units_short=None):
         self.metric = metric
         self.composite = composite
         self.source = source
+        self.units_short = units_short
         if self.composite:
             self.source = None
 
     def get_payload(self):
         return {'metric': self.metric,
                 'composite': self.composite,
-                'source': self.source}
+                'source': self.source,
+                'units_short': self.units_short}

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -73,7 +73,9 @@ class Stream(object):
         self.group_function = group_function
         self.color = color
 
+        # Omit conflicting properties (http://dev.librato.com/v1/instruments)
         if self.composite:
+            self.metric = None
             self.source = None
             self.group_function = None
 

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -11,7 +11,7 @@ class Instrument(object):
                 self.streams.append(i)
             elif isinstance(i, dict):  # Probably parsing JSON here
                 stream = Stream(i.get('metric'), i.get('source'), i.get('composite'),
-                        i.get('units_short'), i.get('units_long'), i.get('min'))
+                        i.get('units_short'), i.get('units_long'), i.get('min'), i.get('max'))
                 self.streams.append(stream)
             else:
                 self.streams.append(Stream(*i))
@@ -35,8 +35,9 @@ class Instrument(object):
                 'streams': self.streams_payload()}
 
     def new_stream(self, metric=None, source='*', composite=None,
-            units_short=None, units_long=None, display_min=None):
-        stream = Stream(metric, source, composite, units_short, units_long, display_min)
+            units_short=None, units_long=None, display_min=None, display_max=None):
+        stream = Stream(metric, source, composite,
+               units_short, units_long, display_min, display_max)
         self.streams.append(stream)
         return stream
 
@@ -59,13 +60,14 @@ class Instrument(object):
 
 class Stream(object):
     def __init__(self, metric=None, source='*', composite=None,
-            units_short=None, units_long=None, display_min=None):
+            units_short=None, units_long=None, display_min=None, display_max=None):
         self.metric = metric
         self.composite = composite
         self.source = source
         self.units_short = units_short
         self.units_long = units_long
         self.display_min = display_min
+        self.display_max = display_max
         if self.composite:
             self.source = None
 
@@ -75,4 +77,5 @@ class Stream(object):
                 'source': self.source,
                 'units_short': self.units_short,
                 'units_long': self.units_long,
-                'min': self.display_min}
+                'min': self.display_min,
+                'max': self.display_max}

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -12,7 +12,8 @@ class Instrument(object):
             elif isinstance(i, dict):  # Probably parsing JSON here
                 stream = Stream(i.get('metric'), i.get('source'), i.get('composite'),
                         i.get('units_short'), i.get('units_long'), i.get('min'), i.get('max'),
-                        i.get('summary_function'), i.get('transform_function'))
+                        i.get('summary_function'), i.get('transform_function'),
+                        i.get('period'))
                 self.streams.append(stream)
             else:
                 self.streams.append(Stream(*i))
@@ -37,10 +38,10 @@ class Instrument(object):
 
     def new_stream(self, metric=None, source='*', composite=None,
             units_short=None, units_long=None, display_min=None, display_max=None,
-            summary_function='average', transform_function=None):
+            summary_function='average', transform_function=None, period=None):
         stream = Stream(metric, source, composite,
                units_short, units_long, display_min, display_max,
-               summary_function, transform_function)
+               summary_function, transform_function, period)
         self.streams.append(stream)
         return stream
 
@@ -64,7 +65,7 @@ class Instrument(object):
 class Stream(object):
     def __init__(self, metric=None, source='*', composite=None,
             units_short=None, units_long=None, display_min=None, display_max=None,
-            summary_function='average', transform_function=None):
+            summary_function='average', transform_function=None, period=None):
         self.metric = metric
         self.composite = composite
         self.source = source
@@ -74,6 +75,7 @@ class Stream(object):
         self.display_max = display_max
         self.summary_function = summary_function
         self.transform_function = transform_function
+        self.period = period
         if self.composite:
             self.source = None
 
@@ -86,4 +88,5 @@ class Stream(object):
                 'min': self.display_min,
                 'max': self.display_max,
                 'summary_function': self.summary_function,
-                'transform_function': self.transform_function}
+                'transform_function': self.transform_function,
+                'period': self.period}

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -11,7 +11,7 @@ class Instrument(object):
                 self.streams.append(i)
             elif isinstance(i, dict):  # Probably parsing JSON here
                 stream = Stream(i.get('metric'), i.get('source'), i.get('composite'),
-                        i.get('units_short'), i.get('units_long'), i.get('min'), i.get('max'))
+                        i.get('units_short'), i.get('units_long'), i.get('min'), i.get('max'), i.get('summary_function'))
                 self.streams.append(stream)
             else:
                 self.streams.append(Stream(*i))
@@ -35,9 +35,9 @@ class Instrument(object):
                 'streams': self.streams_payload()}
 
     def new_stream(self, metric=None, source='*', composite=None,
-            units_short=None, units_long=None, display_min=None, display_max=None):
+            units_short=None, units_long=None, display_min=None, display_max=None, summary_function='average'):
         stream = Stream(metric, source, composite,
-               units_short, units_long, display_min, display_max)
+               units_short, units_long, display_min, display_max, summary_function)
         self.streams.append(stream)
         return stream
 
@@ -60,7 +60,7 @@ class Instrument(object):
 
 class Stream(object):
     def __init__(self, metric=None, source='*', composite=None,
-            units_short=None, units_long=None, display_min=None, display_max=None):
+            units_short=None, units_long=None, display_min=None, display_max=None, summary_function='average'):
         self.metric = metric
         self.composite = composite
         self.source = source
@@ -68,6 +68,7 @@ class Stream(object):
         self.units_long = units_long
         self.display_min = display_min
         self.display_max = display_max
+        self.summary_function = summary_function
         if self.composite:
             self.source = None
 
@@ -78,4 +79,5 @@ class Stream(object):
                 'units_short': self.units_short,
                 'units_long': self.units_long,
                 'min': self.display_min,
-                'max': self.display_max}
+                'max': self.display_max,
+                'summary_function': self.summary_function}

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -202,7 +202,7 @@ class TestLibratoBasic(TestLibratoBase):
         name = "my_INST_with_STREAMS"
         ins = self.conn.create_instrument(name)
         ins_id = ins.id
-        ins.new_stream(composite='s("cpu", "*")', units_short='%')
+        ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage')
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(ins.id)
         assert ins.name == name
@@ -210,6 +210,7 @@ class TestLibratoBasic(TestLibratoBase):
         assert len(ins.streams) == 1
         assert ins.streams[0].composite == 's("cpu", "*")'
         assert ins.streams[0].units_short == '%'
+        assert ins.streams[0].units_long == 'percentage'
 
     def test_instrument_save_creates_new_record(self):
         instrument_name = 'my instrument name'

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -202,7 +202,8 @@ class TestLibratoBasic(TestLibratoBase):
         name = "my_INST_with_STREAMS"
         ins = self.conn.create_instrument(name)
         ins_id = ins.id
-        ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage',
+        ins.new_stream(composite='s("cpu", "*")', name='CPU',
+                units_short='%', units_long='percentage',
                 display_min=0, display_max=100, summary_function='average',
                 transform_function='x/1', period=60)
         self.conn.update_instrument(ins)
@@ -211,6 +212,7 @@ class TestLibratoBasic(TestLibratoBase):
         assert ins.id == ins_id
         assert len(ins.streams) == 1
         assert ins.streams[0].composite == 's("cpu", "*")'
+        assert ins.streams[0].name == 'CPU'
         assert ins.streams[0].units_short == '%'
         assert ins.streams[0].units_long == 'percentage'
         assert ins.streams[0].display_min == 0

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -203,8 +203,8 @@ class TestLibratoBasic(TestLibratoBase):
         ins = self.conn.create_instrument(name)
         ins_id = ins.id
         ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage',
-                display_min=0, display_max=100,
-                summary_function='average', transform_function='x/1')
+                display_min=0, display_max=100, summary_function='average',
+                transform_function='x/1', period=60)
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(ins.id)
         assert ins.name == name
@@ -217,6 +217,7 @@ class TestLibratoBasic(TestLibratoBase):
         assert ins.streams[0].display_max == 100
         assert ins.streams[0].summary_function == 'average'
         assert ins.streams[0].transform_function == 'x/1'
+        assert ins.streams[0].period == 60
 
     def test_instrument_save_creates_new_record(self):
         instrument_name = 'my instrument name'

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -202,7 +202,8 @@ class TestLibratoBasic(TestLibratoBase):
         name = "my_INST_with_STREAMS"
         ins = self.conn.create_instrument(name)
         ins_id = ins.id
-        ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage', display_min=0)
+        ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage',
+                display_min=0, display_max=100)
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(ins.id)
         assert ins.name == name
@@ -212,6 +213,7 @@ class TestLibratoBasic(TestLibratoBase):
         assert ins.streams[0].units_short == '%'
         assert ins.streams[0].units_long == 'percentage'
         assert ins.streams[0].display_min == 0
+        assert ins.streams[0].display_max == 100
 
     def test_instrument_save_creates_new_record(self):
         instrument_name = 'my instrument name'

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -203,7 +203,8 @@ class TestLibratoBasic(TestLibratoBase):
         ins = self.conn.create_instrument(name)
         ins_id = ins.id
         ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage',
-                display_min=0, display_max=100, summary_function='average')
+                display_min=0, display_max=100,
+                summary_function='average', transform_function='x/1')
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(ins.id)
         assert ins.name == name
@@ -215,6 +216,7 @@ class TestLibratoBasic(TestLibratoBase):
         assert ins.streams[0].display_min == 0
         assert ins.streams[0].display_max == 100
         assert ins.streams[0].summary_function == 'average'
+        assert ins.streams[0].transform_function == 'x/1'
 
     def test_instrument_save_creates_new_record(self):
         instrument_name = 'my instrument name'

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -204,7 +204,7 @@ class TestLibratoBasic(TestLibratoBase):
         ins.new_stream(composite='s("cpu", "*")', name='CPU',
                 units_short='%', units_long='percentage',
                 display_min=0, display_max=100, summary_function='average',
-                transform_function='x/1', period=60)
+                transform_function='x/1', period=60, color='#52D74C')
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(ins.id)
         assert ins.name == name
@@ -219,6 +219,7 @@ class TestLibratoBasic(TestLibratoBase):
         assert ins.streams[0].summary_function == 'average'
         assert ins.streams[0].transform_function == 'x/1'
         assert ins.streams[0].period == 60
+        assert ins.streams[0].color == '#52D74C'
 
     def test_adding_a_new_instrument_with_metric_stream_properties(self):
         name = "my_INST_with_STREAMS"
@@ -227,7 +228,7 @@ class TestLibratoBasic(TestLibratoBase):
         ins.new_stream(metric='cpu', name='CPU', source='*',
                 units_short='%', units_long='percentage',
                 display_min=0, display_max=100, summary_function='average',
-                transform_function='x/1', period=60, group_function='average')
+                transform_function='x/1', period=60, group_function='average', color='#52D74C')
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(ins.id)
         assert ins.name == name
@@ -244,6 +245,7 @@ class TestLibratoBasic(TestLibratoBase):
         assert ins.streams[0].transform_function == 'x/1'
         assert ins.streams[0].period == 60
         assert ins.streams[0].group_function == 'average'
+        assert ins.streams[0].color == '#52D74C'
 
     def test_instrument_save_creates_new_record(self):
         instrument_name = 'my instrument name'

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -197,8 +197,7 @@ class TestLibratoBasic(TestLibratoBase):
 
         _c.create_dashboard("foo_", instruments = [ { "id": 1 }, { "id": 2 } ] )
         """
-
-    def test_adding_a_new_instrument_with_stream_properties(self):
+    def test_adding_a_new_instrument_with_composite_stream_properties(self):
         name = "my_INST_with_STREAMS"
         ins = self.conn.create_instrument(name)
         ins_id = ins.id
@@ -220,6 +219,31 @@ class TestLibratoBasic(TestLibratoBase):
         assert ins.streams[0].summary_function == 'average'
         assert ins.streams[0].transform_function == 'x/1'
         assert ins.streams[0].period == 60
+
+    def test_adding_a_new_instrument_with_metric_stream_properties(self):
+        name = "my_INST_with_STREAMS"
+        ins = self.conn.create_instrument(name)
+        ins_id = ins.id
+        ins.new_stream(metric='cpu', name='CPU', source='*',
+                units_short='%', units_long='percentage',
+                display_min=0, display_max=100, summary_function='average',
+                transform_function='x/1', period=60, group_function='average')
+        self.conn.update_instrument(ins)
+        ins = self.conn.get_instrument(ins.id)
+        assert ins.name == name
+        assert ins.id == ins_id
+        assert len(ins.streams) == 1
+        assert ins.streams[0].metric == 'cpu'
+        assert ins.streams[0].name == 'CPU'
+        assert ins.streams[0].source == '*'
+        assert ins.streams[0].units_short == '%'
+        assert ins.streams[0].units_long == 'percentage'
+        assert ins.streams[0].display_min == 0
+        assert ins.streams[0].display_max == 100
+        assert ins.streams[0].summary_function == 'average'
+        assert ins.streams[0].transform_function == 'x/1'
+        assert ins.streams[0].period == 60
+        assert ins.streams[0].group_function == 'average'
 
     def test_instrument_save_creates_new_record(self):
         instrument_name = 'my instrument name'

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -198,17 +198,18 @@ class TestLibratoBasic(TestLibratoBase):
         _c.create_dashboard("foo_", instruments = [ { "id": 1 }, { "id": 2 } ] )
         """
 
-    def test_adding_a_new_instrument_with_composite_metric_stream(self):
+    def test_adding_a_new_instrument_with_stream_properties(self):
         name = "my_INST_with_STREAMS"
         ins = self.conn.create_instrument(name)
         ins_id = ins.id
-        ins.new_stream(composite='s("cpu", "*")')
+        ins.new_stream(composite='s("cpu", "*")', units_short='%')
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(ins.id)
         assert ins.name == name
         assert ins.id == ins_id
         assert len(ins.streams) == 1
         assert ins.streams[0].composite == 's("cpu", "*")'
+        assert ins.streams[0].units_short == '%'
 
     def test_instrument_save_creates_new_record(self):
         instrument_name = 'my instrument name'

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -202,7 +202,7 @@ class TestLibratoBasic(TestLibratoBase):
         name = "my_INST_with_STREAMS"
         ins = self.conn.create_instrument(name)
         ins_id = ins.id
-        ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage')
+        ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage', display_min=0)
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(ins.id)
         assert ins.name == name
@@ -211,6 +211,7 @@ class TestLibratoBasic(TestLibratoBase):
         assert ins.streams[0].composite == 's("cpu", "*")'
         assert ins.streams[0].units_short == '%'
         assert ins.streams[0].units_long == 'percentage'
+        assert ins.streams[0].display_min == 0
 
     def test_instrument_save_creates_new_record(self):
         instrument_name = 'my instrument name'

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -203,7 +203,7 @@ class TestLibratoBasic(TestLibratoBase):
         ins = self.conn.create_instrument(name)
         ins_id = ins.id
         ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage',
-                display_min=0, display_max=100)
+                display_min=0, display_max=100, summary_function='average')
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(ins.id)
         assert ins.name == name
@@ -214,6 +214,7 @@ class TestLibratoBasic(TestLibratoBase):
         assert ins.streams[0].units_long == 'percentage'
         assert ins.streams[0].display_min == 0
         assert ins.streams[0].display_max == 100
+        assert ins.streams[0].summary_function == 'average'
 
     def test_instrument_save_creates_new_record(self):
         instrument_name = 'my instrument name'

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -66,7 +66,8 @@ class TestLibratoInstruments(unittest.TestCase):
         assert len(ins.streams) == 0
         assert ins.id == 1
 
-        ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage', display_min=0)
+        ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage',
+                display_min=0, display_max=100)
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(1)
         assert ins.name == name
@@ -76,6 +77,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.streams[0].units_short == '%'
         assert ins.streams[0].units_long == 'percentage'
         assert ins.streams[0].display_min == 0
+        assert ins.streams[0].display_max == 100
 
     def test_is_persisted(self):
         i = librato.Instrument(self.conn, 'test inst')

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -67,8 +67,8 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.id == 1
 
         ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage',
-                display_min=0, display_max=100,
-                summary_function='average', transform_function='x/1')
+                display_min=0, display_max=100, summary_function='average',
+                transform_function='x/1', period=60)
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(1)
         assert ins.name == name
@@ -81,6 +81,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.streams[0].display_max == 100
         assert ins.streams[0].summary_function == 'average'
         assert ins.streams[0].transform_function == 'x/1'
+        assert ins.streams[0].period == 60
 
     def test_is_persisted(self):
         i = librato.Instrument(self.conn, 'test inst')

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -69,7 +69,7 @@ class TestLibratoInstruments(unittest.TestCase):
         ins.new_stream(composite='s("cpu", "*")', name='CPU',
                 units_short='%', units_long='percentage',
                 display_min=0, display_max=100, summary_function='average',
-                transform_function='x/1', period=60)
+                transform_function='x/1', period=60, color='#52D74C')
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(1)
         assert ins.name == name
@@ -84,6 +84,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.streams[0].summary_function == 'average'
         assert ins.streams[0].transform_function == 'x/1'
         assert ins.streams[0].period == 60
+        assert ins.streams[0].color == '#52D74C'
 
     def test_adding_a_new_instrument_with_metric_stream_properties(self):
         name = "my_INST_with_STREAMS"
@@ -96,7 +97,8 @@ class TestLibratoInstruments(unittest.TestCase):
         ins.new_stream(metric='cpu', name='CPU', source='*',
                 units_short='%', units_long='percentage',
                 display_min=0, display_max=100, summary_function='average',
-                transform_function='x/1', period=60, group_function='average')
+                transform_function='x/1', period=60,
+                group_function='average', color='#52D74C')
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(1)
         assert ins.name == name
@@ -113,6 +115,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.streams[0].transform_function == 'x/1'
         assert ins.streams[0].period == 60
         assert ins.streams[0].group_function == 'average'
+        assert ins.streams[0].color == '#52D74C'
 
     def test_is_persisted(self):
         i = librato.Instrument(self.conn, 'test inst')

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -67,7 +67,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.id == 1
 
         ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage',
-                display_min=0, display_max=100)
+                display_min=0, display_max=100, summary_function='average')
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(1)
         assert ins.name == name
@@ -78,6 +78,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.streams[0].units_long == 'percentage'
         assert ins.streams[0].display_min == 0
         assert ins.streams[0].display_max == 100
+        assert ins.streams[0].summary_function == 'average'
 
     def test_is_persisted(self):
         i = librato.Instrument(self.conn, 'test inst')

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -58,7 +58,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert si.streams[0].metric == "a_gauge"
         assert si.streams[0].composite == None
 
-    def test_adding_a_new_instrument_with_composite_metric_stream(self):
+    def test_adding_a_new_instrument_with_stream_properties(self):
         name = "my_INST_with_STREAMS"
         ins = self.conn.create_instrument(name)
         assert type(ins) == librato.Instrument
@@ -66,13 +66,14 @@ class TestLibratoInstruments(unittest.TestCase):
         assert len(ins.streams) == 0
         assert ins.id == 1
 
-        ins.new_stream(composite='my_composite_string_with_no_validation')
+        ins.new_stream(composite='s("cpu", "*")', units_short='%')
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(1)
         assert ins.name == name
         assert len(ins.streams) == 1
         assert ins.id == 1
-        assert ins.streams[0].composite == "my_composite_string_with_no_validation"
+        assert ins.streams[0].composite == 's("cpu", "*")'
+        assert ins.streams[0].units_short == '%'
 
     def test_is_persisted(self):
         i = librato.Instrument(self.conn, 'test inst')

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -58,7 +58,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert si.streams[0].metric == "a_gauge"
         assert si.streams[0].composite == None
 
-    def test_adding_a_new_instrument_with_stream_properties(self):
+    def test_adding_a_new_instrument_with_composite_stream_properties(self):
         name = "my_INST_with_STREAMS"
         ins = self.conn.create_instrument(name)
         assert type(ins) == librato.Instrument
@@ -84,6 +84,35 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.streams[0].summary_function == 'average'
         assert ins.streams[0].transform_function == 'x/1'
         assert ins.streams[0].period == 60
+
+    def test_adding_a_new_instrument_with_metric_stream_properties(self):
+        name = "my_INST_with_STREAMS"
+        ins = self.conn.create_instrument(name)
+        assert type(ins) == librato.Instrument
+        assert ins.name == name
+        assert len(ins.streams) == 0
+        assert ins.id == 1
+
+        ins.new_stream(metric='cpu', name='CPU', source='*',
+                units_short='%', units_long='percentage',
+                display_min=0, display_max=100, summary_function='average',
+                transform_function='x/1', period=60, group_function='average')
+        self.conn.update_instrument(ins)
+        ins = self.conn.get_instrument(1)
+        assert ins.name == name
+        assert len(ins.streams) == 1
+        assert ins.id == 1
+        assert ins.streams[0].metric == 'cpu'
+        assert ins.streams[0].name == 'CPU'
+        assert ins.streams[0].source == '*'
+        assert ins.streams[0].units_short == '%'
+        assert ins.streams[0].units_long == 'percentage'
+        assert ins.streams[0].display_min == 0
+        assert ins.streams[0].display_max == 100
+        assert ins.streams[0].summary_function == 'average'
+        assert ins.streams[0].transform_function == 'x/1'
+        assert ins.streams[0].period == 60
+        assert ins.streams[0].group_function == 'average'
 
     def test_is_persisted(self):
         i = librato.Instrument(self.conn, 'test inst')

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -67,7 +67,8 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.id == 1
 
         ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage',
-                display_min=0, display_max=100, summary_function='average')
+                display_min=0, display_max=100,
+                summary_function='average', transform_function='x/1')
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(1)
         assert ins.name == name
@@ -79,6 +80,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.streams[0].display_min == 0
         assert ins.streams[0].display_max == 100
         assert ins.streams[0].summary_function == 'average'
+        assert ins.streams[0].transform_function == 'x/1'
 
     def test_is_persisted(self):
         i = librato.Instrument(self.conn, 'test inst')

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -66,7 +66,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert len(ins.streams) == 0
         assert ins.id == 1
 
-        ins.new_stream(composite='s("cpu", "*")', units_short='%')
+        ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage')
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(1)
         assert ins.name == name
@@ -74,6 +74,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.id == 1
         assert ins.streams[0].composite == 's("cpu", "*")'
         assert ins.streams[0].units_short == '%'
+        assert ins.streams[0].units_long == 'percentage'
 
     def test_is_persisted(self):
         i = librato.Instrument(self.conn, 'test inst')

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -33,13 +33,14 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.id == 1
 
         self.conn.submit('a_gauge', 12, description='the desc for a gauge')
-        ins.new_stream('a_gauge')
+        ins.new_stream('a_gauge', source='a_source')
         self.conn.update_instrument(ins)
         #list_ins = self.conn.list_instruments()
         assert ins.name == name
         assert len(ins.streams) == 1
         assert ins.id == 1
-        assert ins.streams[0].metric == "a_gauge"
+        assert ins.streams[0].metric == 'a_gauge'
+        assert ins.streams[0].source == 'a_source'
         assert ins.streams[0].composite == None
 
     def test_get_instrument(self):
@@ -47,7 +48,7 @@ class TestLibratoInstruments(unittest.TestCase):
         ins = self.conn.create_instrument(name)
 
         self.conn.submit('a_gauge', 12, description='the desc for a gauge')
-        ins.new_stream('a_gauge')
+        ins.new_stream('a_gauge', color='#52D74C')
         self.conn.update_instrument(ins)
 
         si = self.conn.get_instrument(ins.id)  # si ; same instrument
@@ -55,8 +56,9 @@ class TestLibratoInstruments(unittest.TestCase):
         assert si.name == name
         assert len(si.streams) == 1
         assert si.id == 1
-        assert si.streams[0].metric == "a_gauge"
+        assert si.streams[0].metric == 'a_gauge'
         assert si.streams[0].composite == None
+        assert si.streams[0].color == '#52D74C'
 
     def test_adding_a_new_instrument_with_composite_stream_properties(self):
         name = "my_INST_with_STREAMS"

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -66,7 +66,8 @@ class TestLibratoInstruments(unittest.TestCase):
         assert len(ins.streams) == 0
         assert ins.id == 1
 
-        ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage',
+        ins.new_stream(composite='s("cpu", "*")', name='CPU',
+                units_short='%', units_long='percentage',
                 display_min=0, display_max=100, summary_function='average',
                 transform_function='x/1', period=60)
         self.conn.update_instrument(ins)
@@ -75,6 +76,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert len(ins.streams) == 1
         assert ins.id == 1
         assert ins.streams[0].composite == 's("cpu", "*")'
+        assert ins.streams[0].name == 'CPU'
         assert ins.streams[0].units_short == '%'
         assert ins.streams[0].units_long == 'percentage'
         assert ins.streams[0].display_min == 0

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -66,7 +66,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert len(ins.streams) == 0
         assert ins.id == 1
 
-        ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage')
+        ins.new_stream(composite='s("cpu", "*")', units_short='%', units_long='percentage', display_min=0)
         self.conn.update_instrument(ins)
         ins = self.conn.get_instrument(1)
         assert ins.name == name
@@ -75,6 +75,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.streams[0].composite == 's("cpu", "*")'
         assert ins.streams[0].units_short == '%'
         assert ins.streams[0].units_long == 'percentage'
+        assert ins.streams[0].display_min == 0
 
     def test_is_persisted(self):
         i = librato.Instrument(self.conn, 'test inst')

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -119,6 +119,26 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.streams[0].group_function == 'average'
         assert ins.streams[0].color == '#52D74C'
 
+    def test_adding_a_new_instrument_omits_composite_conflicting_properties(self):
+        name = "my_INST_with_STREAMS"
+        ins = self.conn.create_instrument(name)
+        assert type(ins) == librato.Instrument
+        assert ins.name == name
+        assert len(ins.streams) == 0
+        assert ins.id == 1
+
+        ins.new_stream(composite='s("cpu", "*")', name='CPU',
+                metric='cpu', source='*', group_function='average')
+        self.conn.update_instrument(ins)
+        ins = self.conn.get_instrument(1)
+        assert ins.name == name
+        assert len(ins.streams) == 1
+        assert ins.id == 1
+        assert ins.streams[0].composite == 's("cpu", "*")'
+        assert ins.streams[0].metric == None
+        assert ins.streams[0].source == None
+        assert ins.streams[0].group_function == None
+
     def test_is_persisted(self):
         i = librato.Instrument(self.conn, 'test inst')
         assert i.is_persisted() == False


### PR DESCRIPTION
I wrote the ones that I'm missing right now but I can write all of them if you agree about this kind of approach. 

Reference: [http://dev.librato.com/v1/instruments](http://dev.librato.com/v1/instruments) (Stream Properties section)

TODO
 - [x] Validate WIP with maintainers
 - [x] Add support for group_function
 - [x] Add support for color
 - [x] Add support for name
 - [x] Enhance composite validation based on:
 - `A composite metric query string to execute when this stream is displayed. This can not be specified with a metric, source or group_function.`
 - [x] Update README.md