### PR TITLE
Add all possible attributes to Stream model

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ chart.rename('new chart name')
 ### Add new metrics to a Chart
 ```python
 chart = space.charts()[-1]
+chart.new_stream('foo', '*')
 chart.new_stream(metric='foo', source='*')
 chart.new_stream(composite='s("foo", "*")')
 chart.save()

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -7,13 +7,13 @@ class Instrument(object):
         self.connection = connection
         self.name = name
         self.streams = []
-        for i in streams:
-            if isinstance(i, Stream):
-                self.streams.append(i)
-            elif isinstance(i, dict):  # Probably parsing JSON here
-                self.streams.append(Stream(i.get('metric'), i.get('source'), i.get('composite')))
+        for s in streams:
+            if isinstance(s, Stream):
+                self.streams.append(s)
+            elif isinstance(s, dict):
+                self.streams.append(Stream(**s))
             else:
-                self.streams.append(Stream(*i))
+                self.streams.append(Stream(*s))
         self.attributes = attributes
         self.id = id
 
@@ -33,8 +33,8 @@ class Instrument(object):
                 'attributes': self.attributes,
                 'streams': self.streams_payload()}
 
-    def new_stream(self, metric=None, source='*', composite=None):
-        stream = Stream(metric, source, composite)
+    def new_stream(self, **kwargs):
+        stream = Stream(**kwargs)
         self.streams.append(stream)
         return stream
 

--- a/librato/instruments.py
+++ b/librato/instruments.py
@@ -33,8 +33,8 @@ class Instrument(object):
                 'attributes': self.attributes,
                 'streams': self.streams_payload()}
 
-    def new_stream(self, **kwargs):
-        stream = Stream(**kwargs)
+    def new_stream(self, metric=None, source='*', **kwargs):
+        stream = Stream(metric, source, **kwargs)
         self.streams.append(stream)
         return stream
 

--- a/librato/spaces.py
+++ b/librato/spaces.py
@@ -194,8 +194,8 @@ class Chart(object):
     def streams_payload(self):
         return [s.get_payload() for s in self.streams]
 
-    def new_stream(self, **kwargs):
-        stream = Stream(**kwargs)
+    def new_stream(self, metric=None, source='*', **kwargs):
+        stream = Stream(metric, source, **kwargs)
         self.streams.append(stream)
         return stream
 

--- a/librato/spaces.py
+++ b/librato/spaces.py
@@ -194,8 +194,8 @@ class Chart(object):
     def streams_payload(self):
         return [s.get_payload() for s in self.streams]
 
-    def new_stream(self, metric=None, source='*', composite=None):
-        stream = Stream(metric, source, composite)
+    def new_stream(self, **kwargs):
+        stream = Stream(**kwargs)
         self.streams.append(stream)
         return stream
 

--- a/librato/streams.py
+++ b/librato/streams.py
@@ -1,11 +1,22 @@
 class Stream(object):
     def __init__(self, metric=None, source='*', composite=None,
+                 name=None, type=None, id=None,
                  group_function=None, summary_function=None,
                  transform_function=None, downsample_function=None,
-                 period=None, id=None, type=None):
+                 period=None, split_axis=None,
+                 min=None, max=None,
+                 units_short=None, units_long=None,
+                 # deprecated
+                 composite_function=None
+                 ):
         self.metric = metric
-        self.composite = composite
         self.source = source
+        # Spaces API
+        self.composite = composite
+        # For instrument compatibility
+        self.name = name
+        self.type = type
+        self.id = id
         # average, sum, min, max, breakout
         self.group_function = group_function
         # average, sum, min, max, count (or derivative if counter)
@@ -13,17 +24,26 @@ class Stream(object):
         self.transform_function = transform_function
         self.downsample_function = downsample_function
         self.period = period
-        self.type = type
+        self.split_axis = split_axis
+        self.min = min
+        self.max = max
+        self.units_short = units_short
+        self.units_long = units_long
+
+        # Can't have a composite and source/metric
         if self.composite:
             self.source = None
+            self.metric = None
+
+    def _attrs(self):
+        return ['metric', 'source', 'composite', 'name',
+            'type', 'id', 'group_function', 'summary_function', 'transform_function', 'downsample_function',
+            'period', 'split_axis', 'min', 'max', 'units_short', 'units_long']
+
 
     def get_payload(self):
-        payload = {
-            'metric': self.metric,
-            'source': self.source
-        }
-        attrs = ['composite', 'period', 'group_function', 'summary_function']
-        for attr in attrs:
+        payload = {}
+        for attr in self._attrs():
             if getattr(self, attr) is not None:
                 payload[attr] = getattr(self, attr)
         return payload

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -247,7 +247,7 @@ class TestChartModel(ChartsTest):
     def test_new_stream_defaults(self):
         chart = Chart(self.conn, 'test')
         self.assertEqual(len(chart.streams), 0)
-        stream = chart.new_stream(metric='my.metric')
+        stream = chart.new_stream('my.metric')
         self.assertIsInstance(stream, Stream)
         self.assertEqual(stream.metric, 'my.metric')
         self.assertEqual(stream.source, '*')
@@ -261,7 +261,7 @@ class TestChartModel(ChartsTest):
 
     def test_new_stream_with_source(self):
         chart = Chart(self.conn, 'test')
-        stream = chart.new_stream(metric='my.metric', source='prod*')
+        stream = chart.new_stream('my.metric', 'prod*')
         self.assertEqual(stream.metric, 'my.metric')
         self.assertEqual(stream.source, 'prod*')
         self.assertEqual(stream.composite, None)

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -68,7 +68,7 @@ class TestChartsConnection(ChartsTest):
         chart = self.conn.create_chart("Chart with no streams", self.space)
         metric_name = 'my.metric'
         self.conn.submit(metric_name, 42, description='metric description')
-        chart.new_stream(metric_name)
+        chart.new_stream(metric=metric_name)
         chart.save()
         self.assertEqual(len(chart.streams), 1)
         stream = chart.streams[0]
@@ -247,7 +247,7 @@ class TestChartModel(ChartsTest):
     def test_new_stream_defaults(self):
         chart = Chart(self.conn, 'test')
         self.assertEqual(len(chart.streams), 0)
-        stream = chart.new_stream('my.metric')
+        stream = chart.new_stream(metric='my.metric')
         self.assertIsInstance(stream, Stream)
         self.assertEqual(stream.metric, 'my.metric')
         self.assertEqual(stream.source, '*')
@@ -261,7 +261,7 @@ class TestChartModel(ChartsTest):
 
     def test_new_stream_with_source(self):
         chart = Chart(self.conn, 'test')
-        stream = chart.new_stream('my.metric', 'prod*')
+        stream = chart.new_stream(metric='my.metric', source='prod*')
         self.assertEqual(stream.metric, 'my.metric')
         self.assertEqual(stream.source, 'prod*')
         self.assertEqual(stream.composite, None)

--- a/tests/test_instruments.py
+++ b/tests/test_instruments.py
@@ -33,7 +33,7 @@ class TestLibratoInstruments(unittest.TestCase):
         assert ins.id == 1
 
         self.conn.submit('a_gauge', 12, description='the desc for a gauge')
-        ins.new_stream('a_gauge')
+        ins.new_stream(metric='a_gauge')
         self.conn.update_instrument(ins)
         #list_ins = self.conn.list_instruments()
         assert ins.name == name
@@ -47,7 +47,7 @@ class TestLibratoInstruments(unittest.TestCase):
         ins = self.conn.create_instrument(name)
 
         self.conn.submit('a_gauge', 12, description='the desc for a gauge')
-        ins.new_stream('a_gauge')
+        ins.new_stream(metric='a_gauge')
         self.conn.update_instrument(ins)
 
         si = self.conn.get_instrument(ins.id)  # si ; same instrument

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -57,9 +57,55 @@ class TestStreamModel(unittest.TestCase):
         self.assertIsNone(Stream().type)
         self.assertEqual(Stream(type='gauge').type, 'gauge')
 
+    def test_init_split_axis(self):
+        self.assertIsNone(Stream().split_axis)
+        self.assertTrue(Stream(split_axis=True).split_axis)
+        self.assertFalse(Stream(split_axis=False).split_axis)
+
+    def test_init_min_max(self):
+        self.assertIsNone(Stream().min)
+        self.assertIsNone(Stream().max)
+        self.assertEqual(Stream(min=-2).min, -2)
+        self.assertEqual(Stream(max=42).max, 42)
+
+    def test_init_units(self):
+        self.assertIsNone(Stream().units_short)
+        self.assertIsNone(Stream().units_long)
+        self.assertEqual(Stream(units_short='req/s').units_short, 'req/s')
+        self.assertEqual(Stream(units_long='requests per second').units_long, 'requests per second')
+
     def test_get_payload(self):
-        self.assertEqual(Stream('my.metric').get_payload(),
+        self.assertEqual(Stream(metric='my.metric').get_payload(),
             {'metric': 'my.metric', 'source': '*'})
+
+    def test_payload_all_attributes(self):
+        s = Stream(metric='my.metric', source='*', name='my display name',
+            type='gauge', id=1234,
+            group_function='min', summary_function='max',
+            transform_function='x/p', downsample_function='min',
+            period=60, split_axis=False,
+            min=0, max=42,
+            units_short='req/s', units_long='requests per second')
+        payload = {
+            'metric': 'my.metric',
+            'source': '*',
+            'name': 'my display name',
+            'type': 'gauge',
+            'id': 1234,
+            'group_function': 'min',
+            'summary_function': 'max',
+            'transform_function': 'x/p',
+            'downsample_function': 'min',
+            'period': 60,
+            'split_axis': False,
+            'min': 0,
+            'max': 42,
+            'units_short': 'req/s',
+            'units_long': 'requests per second'
+        }
+        self.assertEqual(s.get_payload(), payload)
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The `Stream` model is used by both `Instrument` and `Chart` but did not support all of the possible stream attributes. This should allow all stream properties to be read/written.

@drio any objections here?