### PR TITLE
Fix issue with parsing 'error' key vs 'errors' key from API

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -96,6 +96,15 @@ class TestClientError(unittest.TestCase):
         ex = exceptions.ClientError(400, {"errors": {"request": ["Not found"]}})
         self.assertEqual("[400] request: Not found", ex.error_message())
 
+    def test_error_vs_errors(self):
+        msg = "You have hit the rate limit, etc"
+        # The API actually returns 'errors' in most cases, but for rate
+        # limiting we get 'error' (singular)
+        error_resp = {'request_time': 1467306906, 'error': msg}
+        ex = exceptions.ClientError(403, error_resp)
+        parsed_msg = ex._parse_error_message()
+        self.assertEqual(msg, parsed_msg)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #118 allowing correct parsing of the `'error'` key that comes back in a rate limiting message (the API typically returns `'errors'` which were parsing ok).