### PR TITLE
Add gap_detection attribute to Stream and allow extra attributes

### DIFF
--- a/librato/streams.py
+++ b/librato/streams.py
@@ -3,11 +3,11 @@ class Stream(object):
                  name=None, type=None, id=None,
                  group_function=None, summary_function=None,
                  transform_function=None, downsample_function=None,
-                 period=None, split_axis=None,
+                 period=None, split_axis=None, gap_detection=None,
                  min=None, max=None,
                  units_short=None, units_long=None, color=None,
                  # deprecated
-                 composite_function=None
+                 composite_function=None, **kwargs
                  ):
         self.metric = metric
         self.source = source
@@ -30,6 +30,11 @@ class Stream(object):
         self.units_short = units_short
         self.units_long = units_long
         self.color = color
+        self.gap_detection = gap_detection
+
+        # Pick up any attributes that are not explicitly defined
+        for attr in kwargs:
+            setattr(self, attr, kwargs[attr])
 
         # Can't have a composite and source/metric
         if self.composite:

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -74,6 +74,24 @@ class TestStreamModel(unittest.TestCase):
         self.assertEqual(Stream(units_short='req/s').units_short, 'req/s')
         self.assertEqual(Stream(units_long='requests per second').units_long, 'requests per second')
 
+    def test_init_color(self):
+        self.assertIsNone(Stream().color)
+        self.assertEqual(Stream(color='#f00').color, '#f00')
+
+    def test_init_gap_detection(self):
+        self.assertIsNone(Stream().gap_detection)
+        self.assertTrue(Stream(gap_detection=True).gap_detection)
+        self.assertFalse(Stream(gap_detection=False).gap_detection)
+
+    # Adding this to avoid exceptions raised due to unknown Stream attributes
+    def test_init_with_extra_attributes(self):
+        attrs = {"color": "#f00", "something": "foo"}
+        s = Stream(**attrs)
+        # color is a known attribute
+        self.assertEqual(s.color, '#f00')
+        self.assertEqual(s.something, 'foo')
+
+
     def test_get_payload(self):
         self.assertEqual(Stream(metric='my.metric').get_payload(),
             {'metric': 'my.metric', 'source': '*'})


### PR DESCRIPTION
Fix for the `gap_detection` attribute on `Stream` model that currently throws an exception. Also adding `**kwargs` to accept any additional attributes that come back from the API. One such attribute is `position` which is not published or used, but exists on some Librato internal streams - so this will cover that as well.