### PR TITLE
Added a function to be able to encode lists

### DIFF
--- a/librato/__init__.py
+++ b/librato/__init__.py
@@ -128,12 +128,14 @@ class LibratoConnection(object):
         return headers
 
     def _url_encode_params(self, params={}):
-        if not isinstance(params, dict): 
+        if not isinstance(params, dict):
             raise Exception("You must pass in a dictionary!")
         params_list = []
         for k,v in params.items():
-            if isinstance(v, list): params_list.extend([(k+'[]', x) for x in v])
-            else: params_list.append((k, v))
+            if isinstance(v, list):
+                params_list.extend([(k+'[]', x) for x in v])
+            else:
+                params_list.append((k, v))
         return urlencode(params_list)
 
     def _make_request(self, conn, path, headers, query_props, method):

--- a/librato/__init__.py
+++ b/librato/__init__.py
@@ -127,6 +127,15 @@ class LibratoConnection(object):
         headers['User-Agent'] = ' '.join(ua_chunks)
         return headers
 
+    def _url_encode_params(self, params={}):
+        if not isinstance(params, dict): 
+            raise Exception("You must pass in a dictionary!")
+        params_list = []
+        for k,v in params.items():
+            if isinstance(v, list): params_list.extend([(k+'[]', x) for x in v])
+            else: params_list.append((k, v))
+        return urlencode(params_list)
+
     def _make_request(self, conn, path, headers, query_props, method):
         """ Perform the an https request to the server """
         uri = self.base_path + path
@@ -136,7 +145,7 @@ class LibratoConnection(object):
                 body = json.dumps(query_props)
                 headers['Content-Type'] = "application/json"
             else:
-                uri += "?" + urlencode(query_props)
+                uri += "?" + self._url_encode_params(query_props)
 
         log.info("method=%s uri=%s" % (method, uri))
         log.info("body(->): %s" % body)

--- a/tests/test_param_url_encoding.py
+++ b/tests/test_param_url_encoding.py
@@ -1,0 +1,23 @@
+import logging
+import unittest
+import librato
+
+class TestLibratoUrlEncoding(unittest.TestCase):
+
+    def setUp(self):
+        self.conn = librato.connect('user_test', 'key_test')
+
+    def test_string_encoding(self):
+        params = {"name":"abcd"}
+        assert self.conn._url_encode_params(params) == 'name=abcd'
+
+    def test_list_encoding(self):
+        params = {"sources": ['a','b']}
+        assert self.conn._url_encode_params(params) == 'sources%5B%5D=a&sources%5B%5D=b'
+
+    def test_empty_encoding(self):
+        params = {}
+        assert self.conn._url_encode_params(params) == ''
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
now you can send list params:

```
stream = api.get_annotation_stream("app-deploys", start_time="1234500000", sources=['a', 'b'])
```

before that would throw an error

>librato.exceptions.BadRequest: [400] params: sources: must be an array