### PR TITLE
(GITHUB-89) Do not throw ValueError on authentication error during POST

### DIFF
--- a/tests/mock_connection.py
+++ b/tests/mock_connection.py
@@ -446,11 +446,15 @@ class MockResponse(object):
     def __init__(self, request, fake_failure=False):
         self.request = request
         self.status = 500 if fake_failure else 200
+        self._headers = {'content-type': "application/json;charset=utf-8"}
 
     class headers(object):
         @staticmethod
         def get_content_charset(default):
             return 'utf-8'
+
+    def getheader(self, name, default=None):
+        return self._headers.get(name.lower(), default)
 
     def read(self):
         return self._json_body_based_on_request()

--- a/tests/test_process_response.py
+++ b/tests/test_process_response.py
@@ -1,0 +1,46 @@
+import logging
+import unittest
+try:
+    from unittest.mock import create_autospec, PropertyMock
+except ImportError:
+    from mock import create_autospec, PropertyMock
+import librato
+from mock_connection import MockConnect, server
+from six.moves.http_client import HTTPResponse
+
+#logging.basicConfig(level=logging.DEBUG)
+# Mock the server
+librato.HTTPSConnection = MockConnect
+
+class TestLibrato(unittest.TestCase):
+    def setUp(self):
+        self.conn = librato.connect('user_test', 'key_test')
+        server.clean()
+
+    def test_get_authentication_failure(self):
+        """
+        fails with Unauthorized on 401 during GET
+        """
+        mock_response = create_autospec(HTTPResponse, spec_set=True, instance=True)
+        mock_response.mock_add_spec(['status'], spec_set=True)
+        mock_response.status = 401
+        # GET 401 responds with JSON
+        mock_response.getheader.return_value = "application/json;charset=utf-8"
+        mock_response.read.return_value = '{"errors":{"request":["Authorization Required"]}}'.encode('utf-8')
+
+        with self.assertRaises(librato.exceptions.Unauthorized):
+            self.conn._process_response(mock_response, 1)
+
+    def test_post_authentication_failure(self):
+        """
+        fails with Unauthorized on 401 during POST
+        """
+        mock_response = create_autospec(HTTPResponse, spec_set=True, instance=True)
+        mock_response.mock_add_spec(['status'], spec_set=True)
+        mock_response.status = 401
+        # POST 401 responds with text
+        mock_response.getheader.return_value = "text/plain"
+        mock_response.read.return_value = 'Credentials are required to access this resource.'.encode('utf-8')
+
+        with self.assertRaises(librato.exceptions.Unauthorized):
+            self.conn._process_response(mock_response, 1)


### PR DESCRIPTION
Fix for issue #89 

Before:

```
>>> import librato
>>> conn = librato.connect("user", "invalidcredential")
>>> conn.list_metrics()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../librato/__init__.py", line 222, in list_metrics
    resp = self._mexe("metrics", query_props=query_props)
  File ".../librato/__init__.py", line 191, in _mexe
    resp_data, success, backoff = self._process_response(resp, backoff)
  File ".../librato/__init__.py", line 171, in _process_response
    raise exceptions.get(resp.status, resp_data)
librato.exceptions.Unauthorized: [401] request: Authorization Required

>>> conn.submit("gauge_1", 1, description="desc 1")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../librato/__init__.py", line 246, in submit
    self._mexe("metrics", method="POST", query_props=payload)
  File ".../librato/__init__.py", line 191, in _mexe
    resp_data, success, backoff = self._process_response(resp, backoff)
  File ".../librato/__init__.py", line 167, in _process_response
    resp_data = json.loads(body.decode(_getcharset(resp)))
  File "/usr/lib64/python3.5/json/__init__.py", line 319, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python3.5/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python3.5/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

After:

```
>>> import librato
>>> conn = librato.connect("user", "invalidcredential")
>>> conn.list_metrics()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../python-librato/librato/__init__.py", line 219, in list_metrics
    resp = self._mexe("metrics", query_props=query_props)
  File ".../python-librato/librato/__init__.py", line 188, in _mexe
    resp_data, success, backoff = self._process_response(resp, backoff)
  File ".../python-librato/librato/__init__.py", line 168, in _process_response
    raise exceptions.get(resp.status, resp_data)
librato.exceptions.Unauthorized: [401] request: Authorization Required

>>> conn.submit("gauge_1", 1, description="desc 1")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../python-librato/librato/__init__.py", line 243, in submit
    self._mexe("metrics", method="POST", query_props=payload)
  File ".../python-librato/librato/__init__.py", line 188, in _mexe
    resp_data, success, backoff = self._process_response(resp, backoff)
  File ".../python-librato/librato/__init__.py", line 168, in _process_response
    raise exceptions.get(resp.status, resp_data)
librato.exceptions.Unauthorized: [401] Credentials are required to access this resource.
```