### PR TITLE
Alerts have issues with services and conditions

### DIFF
--- a/librato/__init__.py
+++ b/librato/__init__.py
@@ -420,6 +420,10 @@ class LibratoConnection(object):
         """Create a new alert"""
         payload = Alert(self, name).get_payload()
         for k, v in query_props.items():
+            if k == "services":
+                v = [item._id for item in v]
+            elif isinstance(v, list):
+                v = [item.get_payload() for item in v]
             payload[k] = v
         resp = self._mexe("alerts", method="POST", query_props=payload)
         return Alert.from_dict(self, resp)

--- a/librato/alerts.py
+++ b/librato/alerts.py
@@ -118,13 +118,13 @@ class Condition(object):
     def from_dict(cls, data):
         obj = cls(metric_name=data['metric_name'],
                   source=data['source'])
-        if data['type'] == Condition.ABOVE:
+        if data['condition_type'] == Condition.ABOVE:
             obj.above(data.get('threshold'), data.get('summary_function'))
             obj.duration(data.get('duration'))
-        elif data['type'] == Condition.BELOW:
+        elif data['condition_type'] == Condition.BELOW:
             obj.below(data.get('threshold'), data.get('summary_function'))
             obj.duration(data.get('duration'))
-        elif data['type'] == Condition.ABSENT:
+        elif data['condition_type'] == Condition.ABSENT:
             obj.stops_reporting_for(data.get('duration'))
         return obj
 

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -58,6 +58,21 @@ class TestLibratoAlerts(unittest.TestCase):
         assert len(alert.conditions) == 0
         assert alert.services[0]._id == 1
 
+    def test_adding_a_new_alert_with_a_service_param(self):
+        alert = self.conn.create_alert(self.name, services=[librato.alerts.Service(1)])
+        assert len(alert.services) == 1
+        assert len(alert.conditions) == 0
+        assert alert.services[0]._id == 1
+
+    def test_adding_a_new_alert_with_a_condition_param(self):
+        cond = librato.alerts.Condition(1)
+        cond = cond.above(200, 'average')
+        cond.duration(5)
+        alert = self.conn.create_alert(self.name, conditions=[cond])
+        assert len(alert.services) == 0
+        assert len(alert.conditions) == 1
+        assert alert.conditions[0].metric_name == 1
+
     def test_add_above_condition(self):
         alert = self.conn.create_alert(self.name)
         alert.add_condition_for('metric_test').above(200, 'average').duration(5)


### PR DESCRIPTION
When attempting to create an alert with `services` and `conditions` params, json deserialize would fail.

```
  File "/usr/local/lib/python2.7/site-packages/librato/__init__.py", line 424, in create_alert
    resp = self._mexe("alerts", method="POST", query_props=payload)
  File "/usr/local/lib/python2.7/site-packages/librato/__init__.py", line 188, in _mexe
    resp = self._make_request(conn, path, headers, query_props, method)
  File "/usr/local/lib/python2.7/site-packages/librato/__init__.py", line 149, in _make_request
    body = json.dumps(query_props)
  File "/usr/local/Cellar/python/2.7.12/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 244, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/Cellar/python/2.7.12/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/Cellar/python/2.7.12/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/Cellar/python/2.7.12/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: <librato.alerts.Service object at 0x10ead3110> is not JSON serializable
```

In order to fix this, the conditions needed to be serialized correctly, and the services needed serialization AND encoding for id only.

And of course, add some tests for them.

Also, the `Alert.from_dict` method referenced `type`, not `condition_type`, which I think was introduced in a78e2d13662c3181f257c88c61e2367893647f6e
