### PR TITLE
Allow alerts to be created with Service objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,35 +383,37 @@ for alert in api.list_alerts():
     print(alert.name)
 ```
 
-Create alerts with an _above_ condition:
+Create an alert with an _above_ condition:
 ```python
-alert = api.create_alert("name")
+alert = api.create_alert('my.alert')
 alert.add_condition_for('metric_name').above(1) # trigger immediately
 alert.add_condition_for('metric_name').above(1).duration(60) # trigger after a set duration
 alert.add_condition_for('metric_name').above(1, 'sum') # custom summary function
 alert.save()
 ```
 
-Create alerts with a _below_ condition:
+Create an alert with a _below_ condition:
 ```python
-api.create_alert("name")
+alert = api.create_alert('my.alert', description='An alert description')
 alert.add_condition_for('metric_name').below(1) # the same syntax as above conditions
 alert.save()
 ```
 
-Create alerts with an _absent_ condition:
+Create an alert with an _absent_ condition:
 ```python
-api.create_alert("name")
+alert = api.create_alert('my.alert')
 alert.add_condition_for('metric_name').stops_reporting_for(5) # duration in minutes of the threshold to trigger the alert
 alert.save()
 ```
 
-Add a description to an alert (default description is empty):
+Restrict the condition to a specific source (default is `*`):
 ```python
-api.create_alert("name", description='An alert description')
+alert = api.create_alert('my.alert')
+alert.add_condition_for('metric_name', 'mysource')
+alert.save()
 ```
 
-View all outbound services created by the user. The service ID is included in the response.
+View all outbound services for the current user
 ```python
 for service in api.list_services():
     print(service._id, service.title, service.settings)
@@ -419,28 +421,34 @@ for service in api.list_services():
 
 Create an alert with Service IDs
 ```python
-alert = api.create_alert("name", services=[1234, 5678])
+alert = api.create_alert('my.alert', services=[1234, 5678])
 ```
 
 Create an alert with Service objects
 ```python
 s = api.list_services()
-alert = api.create_alert("name", services=[s[0], s[1]])
+alert = api.create_alert('my.alert', services=[s[0], s[1]])
 ```
 
 Add an outbound service to an alert:
 ```python
-alert = api.create_alert("name")
-alert.add_service("service ID")
+alert = api.create_alert('my.alert')
+alert.add_service(1234)
 alert.save()
 ```
 
-To restrict the alert to a specific source (default is `*`):
+Put it all together:
 ```python
-api.create_alert("name")
-alert.add_condition_for('metric_name', source='source name')
-alert.save()
+cond = {'metric_name': 'cpu', 'type': 'above', 'threshold': 42}
+s = api.list_services()
+api.create_alert('my.alert', conditions=[cond], services=[s[0], s[1]])
+# We have an issue at the API where conditions and services are not returned
+# when creating. So, retrieve back from API
+alert = api.get_alert('my.alert')
+print(alert.conditions)
+print(alert.services)
 ```
+
 
 ## Client-side Aggregation
 

--- a/README.md
+++ b/README.md
@@ -417,6 +417,17 @@ for service in api.list_services():
     print(service._id, service.title, service.settings)
 ```
 
+Create an alert with Service IDs
+```python
+alert = api.create_alert("name", services=[1234, 5678])
+```
+
+Create an alert with Service objects
+```python
+s = api.list_services()
+alert = api.create_alert("name", services=[s[0], s[1]])
+```
+
 Add an outbound service to an alert:
 ```python
 alert = api.create_alert("name")

--- a/librato/__init__.py
+++ b/librato/__init__.py
@@ -418,9 +418,7 @@ class LibratoConnection(object):
     #
     def create_alert(self, name, **query_props):
         """Create a new alert"""
-        payload = Alert(self, name).get_payload()
-        for k, v in query_props.items():
-            payload[k] = v
+        payload = Alert(self, name, **query_props).get_payload()
         resp = self._mexe("alerts", method="POST", query_props=payload)
         return Alert.from_dict(self, resp)
 

--- a/librato/alerts.py
+++ b/librato/alerts.py
@@ -129,16 +129,15 @@ class Condition(object):
         return obj
 
     def get_payload(self):
-        obj = {'condition_type': self.condition_type,
-               'metric_name': self.metric_name,
-               'source': self.source}
+        obj = {
+            'type': self.condition_type,
+            'metric_name': self.metric_name,
+            'source': self.source,
+            'summary_function': self.summary_function,
+            'duration': self._duration
+        }
         if self.condition_type in [self.ABOVE, self.BELOW]:
             obj['threshold'] = self.threshold
-            obj['summary_function'] = self.summary_function
-            obj['duration'] = self._duration
-        elif self.condition_type == self.ABSENT:
-            obj['summary_function'] = self.summary_function
-            obj['duration'] = self._duration
         return obj
 
 

--- a/librato/alerts.py
+++ b/librato/alerts.py
@@ -117,7 +117,7 @@ class Condition(object):
     @classmethod
     def from_dict(cls, data):
         obj = cls(metric_name=data['metric_name'],
-                  source=data['source'])
+                  source=data.get('source', '*'))
         if data['type'] == Condition.ABOVE:
             obj.above(data.get('threshold'), data.get('summary_function'))
             obj.duration(data.get('duration'))

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -51,12 +51,20 @@ class TestLibratoAlerts(unittest.TestCase):
         self.conn.delete_alert('say_my_wrong_name')
         assert self.conn.get_alert('say_my_name') is not None
 
-    def test_adding_a_new_alert_with_a_service(self):
+    def test_create_alert_with_service_id(self):
         alert = self.conn.create_alert(self.name)
-        alert.add_service(1)
-        assert len(alert.services) == 1
-        assert len(alert.conditions) == 0
-        assert alert.services[0]._id == 1
+        service_id = 1234
+        alert.add_service(service_id)
+        self.assertEqual(len(alert.services), 1)
+        self.assertEqual(len(alert.conditions), 0)
+        self.assertEqual(alert.services[0]._id, service_id)
+
+    def test_create_alert_with_service_obj(self):
+        service = librato.alerts.Service(1234)
+        alert = self.conn.create_alert(self.name, services=[service])
+        self.assertEqual(len(alert.services), 1)
+        self.assertEqual(len(alert.conditions), 0)
+        self.assertEqual(alert.services[0]._id, service._id)
 
     def test_add_above_condition(self):
         alert = self.conn.create_alert(self.name)


### PR DESCRIPTION
Enables an `Alert` to be created using a `Service` object, as follows:

```
services = api.list_services()
service = services[0]
alert = api.create_alert('my.new.alert', services=[service])
```

I think this should solve the issues in #141 cc @brmurphy