### PR TITLE
Correctly initialize Space model with tags param

### DIFF
--- a/librato/spaces.py
+++ b/librato/spaces.py
@@ -28,7 +28,8 @@ class Space(object):
         obj = cls(connection,
                   data['name'],
                   id=data['id'],
-                  chart_dicts=data.get('charts'))
+                  chart_dicts=data.get('charts'),
+                  tags=data.get('tags'))
         return obj
 
     def get_payload(self):

--- a/tests/test_spaces.py
+++ b/tests/test_spaces.py
@@ -98,6 +98,11 @@ class TestSpaceModel(SpacesTest):
     def test_init_with_name(self):
         self.assertEqual(Space(self.conn, 'My Space').name, 'My Space')
 
+    def test_init_with_tags(self):
+        self.assertFalse(Space(self.conn, 'My Space').tags)
+        self.assertFalse(Space(self.conn, 'My Space', tags=False).tags)
+        self.assertTrue(Space(self.conn, 'My Space', tags=True).tags)
+
     def test_init_with_empty_name(self):
         self.assertEqual(Space(self.conn, None).name, None)
 


### PR DESCRIPTION
The `tags` parameter was not being initialized on the `Space` model. Fixed that, and added tests.