### PR TITLE
Submit in tag mode if default tags present in queue

### DIFF
--- a/librato/queue.py
+++ b/librato/queue.py
@@ -63,6 +63,9 @@ class Queue(object):
         self.tags.update(d)
 
     def add(self, name, value, type='gauge', **query_props):
+        if len(self.tags) > 0:
+            query_props['tags'] = self.tags
+
         if 'tags' in query_props:
             self.add_tagged(name, value, **query_props)
         else:


### PR DESCRIPTION
If we set a queue with default tags and then we add measurements without a tags argument, we want to use the queue level tags and submit in tag mode. 

Example:

```py
        q = self.api.new_queue(tags={'region': 'us-west', 'name': 'web-prod-3'})
        q.add('_drd_test_beale_cpu', self.rand())
        q.add('_drd_test_beale_memory', self.rand(), tags={})
        q.submit()
```

Requests:

```
INFO:librato:method=POST uri=/v1/measurements
INFO:librato:body(->): {"measurements": [{"count": 1, "sum": 29, "name": "_drd_test_beale_cpu", "tags": {"region": "us-west", "name": "web-prod-3"}}, {"count": 1, "sum": 26, "name": "_drd_test_beale_memory", "tags": {"region": "us-west", "name": "web-prod-3"}}], "tags": {"region": "us-west", "name": "web-prod-3"}}
INFO:librato:body(<-): {"measurements":{"summary":{"total":2,"accepted":2,"failed":0}},"errors":[]}
```
