### PR TITLE
Return all data for `list` methods where appropriate

### DIFF
--- a/librato/__init__.py
+++ b/librato/__init__.py
@@ -364,7 +364,6 @@ class LibratoConnection(object):
             path = "metrics"
         return self._mexe(path, method="DELETE", query_props=payload)
 
-
     #
     # Annotations
     #

--- a/librato/alerts.py
+++ b/librato/alerts.py
@@ -39,6 +39,9 @@ class Alert(object):
     def add_service(self, service_id):
         self.services.append(Service(service_id))
 
+    def __repr__(self):
+        return "%s<%s>" % (self.__class__.__name__, self.name)
+
     @classmethod
     def from_dict(cls, connection, data):
         """Returns an alert object from a dictionary item,
@@ -166,3 +169,6 @@ class Service(object):
             'type': self.type,
             'settings': self.settings
         }
+
+    def __repr__(self):
+        return "%s<%s><%s>" % (self.__class__.__name__, self.type, self.title)

--- a/librato/annotations.py
+++ b/librato/annotations.py
@@ -34,6 +34,9 @@ class Annotation(object):
         self.events = {}
         self.query = {}
 
+    def __repr__(self):
+        return "%s<%s>" % (self.__class__.__name__, self.name)
+
     @classmethod
     def from_dict(cls, connection, data):
         """Returns a metric object from a dictionary item,

--- a/tests/mock_connection.py
+++ b/tests/mock_connection.py
@@ -588,10 +588,10 @@ class MockResponse(object):
         return self._method_is('POST') and self._path_is('/v1/alerts')
 
     def _req_is_list_of_alerts(self):
-        return self._method_is('GET') and self._path_is('/v1/alerts?version=2') and not self._req_is_get_alert()
+        return self._method_is('GET') and self._path_is('/v1/alerts') and not self._req_is_get_alert()
 
     def _req_is_get_alert(self):
-        return self._method_is('GET') and re.match('/v1/alerts\?(version=2|name=.+)\&(name=.+|version=2)',
+        return self._method_is('GET') and re.match('/v1/alerts\?name=.+',
                                                    self.request.uri)
 
     def _req_is_delete_alert(self):

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -141,14 +141,14 @@ class TestService(unittest.TestCase):
         server.clean()
 
     def test_list_services(self):
-        services = self.conn.list_services()
+        services = list(self.conn.list_services())
         self.assertEqual(len(services), 0)
         # Hack this into the server until we have a :create_service
         # method on the actual connection
         server.create_service(self.sample_payload)
         # id is 1
         self.assertEqual(server.services[1], self.sample_payload)
-        services = self.conn.list_services()
+        services = list(self.conn.list_services())
         self.assertEqual(len(services), 1)
         s = services[0]
         self.assertIsInstance(s, librato.alerts.Service)

--- a/tests/test_spaces.py
+++ b/tests/test_spaces.py
@@ -19,11 +19,11 @@ class SpacesTest(unittest.TestCase):
 class TestSpacesConnection(SpacesTest):
     def test_list_spaces(self):
         self.conn.create_space('My Space')
-        self.assertEqual(len(self.conn.list_spaces()), 1)
+        self.assertEqual(len(list(self.conn.list_spaces())), 1)
 
     def test_list_spaces_when_none(self):
         spcs = self.conn.list_spaces()
-        self.assertEqual(len(spcs), 0)
+        self.assertEqual(len(list(spcs)), 0)
 
     # Find a space by ID
     def test_get_space(self):
@@ -67,7 +67,7 @@ class TestSpacesConnection(SpacesTest):
         space = self.conn.create_space('My Space')
         self.conn.update_space(space, name='New Name')
 
-        updated_spaces = self.conn.list_spaces()
+        updated_spaces = list(self.conn.list_spaces())
         self.assertEqual(len(updated_spaces), 1)
 
         updated = updated_spaces[0]
@@ -84,7 +84,7 @@ class TestSpacesConnection(SpacesTest):
     def test_delete_space(self):
         space = self.conn.create_space('My Space')
         self.conn.delete_space(space.id)
-        self.assertEqual(len(self.conn.list_spaces()), 0)
+        self.assertEqual(len(list(self.conn.list_spaces())), 0)
 
 
 class TestSpaceModel(SpacesTest):


### PR DESCRIPTION
- [x] Use generic method for returning all records from paginated results (thanks to #165)
- [x] `list_alerts` returns all alerts (thanks to #165)
- [x] `list_services` returns all services
- [x] `list_spaces` returns all spaces
- [x] `list_annotation_streams` returns all annotations
- [x] Alerts assume `"version": 2` is the default and therefore stop sending the parameter (v1 is deprecated)