### PR TITLE
Updates to prioritize usage of tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@ python-librato
 
 A Python wrapper for the Librato Metrics API.
 
-## Source-based Librato users (legacy)
-Starting in version 3, we have deprecated Dashboards and Instruments in favor of Spaces and Charts.
+## Documentation Notes
+
+- New accounts
+  - Refer to [master](https://github.com/librato/python-librato/tree/master) for the latest documentation.
+- Legacy (source-based) Librato users
+  - Please see the [legacy documentation](https://github.com/librato/python-librato/tree/v2.1.2)
 
 ## Installation
 
@@ -317,13 +321,6 @@ Create an alert with an _absent_ condition:
 ```python
 alert = api.create_alert('my.alert')
 alert.add_condition_for('metric_name').stops_reporting_for(5) # duration in minutes of the threshold to trigger the alert
-alert.save()
-```
-
-Restrict the condition to a specific source (default is `*`):
-```python
-alert = api.create_alert('my.alert')
-alert.add_condition_for('metric_name', 'mysource')
 alert.save()
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ python-librato
 
 A Python wrapper for the Librato Metrics API.
 
-NOTE: Starting in version 3, we have deprecated Dashboards and Instruments in favor of Spaces and Charts.
+## Source-based Librato users (legacy)
+Starting in version 3, we have deprecated Dashboards and Instruments in favor of Spaces and Charts.
 
 ## Installation
 
@@ -23,19 +24,21 @@ From your application or script:
 
 ## Authentication
 
-  We first use our credentials to connect to the API. I am assuming you have
-[a librato account for Metrics](https://metrics.librato.com/). Go to your
-[account settings page](https://metrics.librato.com/account) and save your
+Assuming you have
+[a Librato account](https://metrics.librato.com/), go to your
+[account settings page](https://metrics.librato.com/account) and get your
 username (email address) and token (long hexadecimal string).
 
 ```python
   api = librato.connect('email', 'token')
 ```
 
+### Metric name sanitization
+
 When creating your connection you may choose to provide a sanitization function.
 This will be applied to any metric name you pass in. For example we provide a
 sanitization function that will ensure your metrics are legal librato names.
-This can be set as such
+This can be set as such:
 
 ```python
   api = librato.connect('email', 'token', sanitizer=librato.sanitize_metric_name)
@@ -52,61 +55,40 @@ To iterate over your metrics:
     print m.name
 ```
 
-or use `list_metrics()` to iterate over all your metrics with
+or use `list_all_metrics()` to iterate over all your metrics with
 transparent pagination.
 
-Let's now create a Metric:
+Let's now create a metric:
 
 ```python
-  api.submit("temperature", 10, description="temperature at home")
+  api.submit("temperature", 80, tags={"city": "sf"})
 ```
 
-By default ```submit()``` will create a gauge metric. The metric will be
-created automatically by the server if it does not exist
-
-To create a counter metric (note: counters are expected to be *absolute* counters and take a monotonically increasing value such as network throughput):
-
-```python
-  api.submit("connections", 20, type="counter", description="server connections")
-```
-
-To iterate over your metric names:
+View your metric names:
 
 ```python
   for m in api.list_metrics():
-      print "%s: %s" % (m.name, m.description)
+      print(m.name)
 ```
 
-To retrieve a specific metric:
+To retrieve a metric:
 
 ```python
   # Retrieve metric metadata ONLY
   gauge = api.get("temperature")
   gauge.name # "temperature"
-  gauge.description # "temperature at home"
-  gauge.measurements # {}
-  # Retrive metric with the last measurement seen
-  gauge = api.get("temperature", count=1, resolution=1)
-  gauge.measurements
-  # {u'unassigned': [{u'count': 1, u'sum_squares': 100.0, u'min': 10.0, u'measure_time': 1474988647, u'max': 10.0, u'sum': 10.0, u'value': 10.0}]}
+
+  # Retrieve measurements from last 15 minutes
+  resp = api.get_measurements("temperature", duration=900, resolution=1)
+  # {u'name': u'temperature',
+  # u'links': [],
+  # u'series': [{u'measurements': [
+  #   {u'value': 80.0, u'time': 1502917147}
+  # ],
+  # u'tags': {u'city': u'sf'}}],
+  # u'attributes': {u'created_by_ua': u'python-librato/2.0.0...'
+  # , u'aggregate': False}, u'resolution': 1}
 ```
-
-Iterate over measurements:
-
-```python
-  metric = api.get("temperature", count=100, resolution=1)
-  source = 'unassigned'
-  for m in metric.measurements[source]:
-    print "%s: %s" % (m['value'], m['measure_time'])
-```
-
-Notice a couple of things here. First, we are using the key `unassigned` since
-we have not associated our measurements to any source. If we had specified a
-source such as `sf` we could use it in the same fashion. Read more the
-[API documentation](https://www.librato.com/docs/api/). In addition, notice how
-we are passing the count and resolution parameters to make sure the API
-returns measurements in its answer and not only the metric properties.
-Read more about them [here](https://www.librato.com/docs/api/#retrieve-a-metric-by-name).
 
 To retrieve a composite metric:
 
@@ -115,23 +97,32 @@ To retrieve a composite metric:
   compose = 'mean(s("temperature", "*", {function: "mean", period: "3600"}))'
   import time
   start_time = int(time.time()) - 8 * 3600
-  resp = api.get_composite(compose, start_time=start_time)
-  resp['measurements'][0]['series']
+
+  # For tag-based (new) accounts.
+  # Will be deprecated in favor of `get_composite` in a future tags-only release
+  resp = api.get_composite_tagged(compose, start_time=start_time)
+  resp['series']
   # [
-  #   {u'measure_time': 1421744400, u'value': 41.23944444444444},
-  #   {u'measure_time': 1421748000, u'value': 40.07611111111111},
-  #   {u'measure_time': 1421751600, u'value': 38.77444444444445},
-  #   {u'measure_time': 1421755200, u'value': 38.05833333333333},
-  #   {u'measure_time': 1421758800, u'value': 37.983333333333334},
-  #   {u'measure_time': 1421762400, u'value': 38.93333333333333},
-  #   {u'measure_time': 1421766000, u'value': 40.556666666666665}
+  #   {
+  #     u'query': {u'metric': u'temperature', u'tags': {}},
+  #     u'metric': {u'attributes': {u'created_by_ua': u'statsd-librato-backend/0.1.7'},
+  #     u'type': u'gauge',
+  #     u'name': u'temperature'},
+  #     u'measurements': [{u'value': 42.0, u'time': 1504719992}],
+  #     u'tags': {u'one': u'1'}}],
+  #     u'compose': u's("foo", "*")',
+  #     u'resolution': 1
+  #   }
   # ]
+
+  # For backward compatibility in legacy Librato (source-based)
+  resp = api.get_composite(compose, start_time=start_time)
 ```
 
 To create a saved composite metric:
 
 ```python
-  api.create_composite('humidity', 'sum(s("all.*", "*"))',
+  api.create_composite('composite.humidity', 'sum(s("humidity", "*"))',
       description='a test composite')
 ```
 
@@ -151,11 +142,9 @@ ready, they will be submitted in an efficient manner. Here is an example:
 
 ```python
 api = librato.connect('email', 'token')
-q   = api.new_queue()
-q.add('temperature', 22.1, source='upstairs')
-q.add('temperature', 23.1, source='dowstairs')
-q.add('num_requests', 100, type='counter', source='server1')
-q.add('num_requests', 102, type='counter', source='server2')
+q = api.new_queue()
+q.add('temperature', 22.1, tags={'location': 'downstairs'})
+q.add('temperature', 23.1, tags={'location': 'upstairs'})
 q.submit()
 ```
 
@@ -166,42 +155,18 @@ submit the first measurement as it was the only one successfully added.
 If the operation succeeds both measurements will be submitted.
 
 ```python
-api = librato.connect('email', 'token')
 with api.new_queue() as q:
-    q.add('temperature', 22.1, source='upstairs')
+    q.add('temperature', 22.1, tags={'location': 'downstairs'})
     potentially_dangerous_operation()
-    q.add('num_requests', 100, type='counter', source='server1')
+    q.add('num_requests', 100, tags={'host': 'server1')
 ```
 
 Queues by default will collect metrics until they are told to submit. You may create a queue
 that autosubmits based on metric volume.
 
 ```python
-api = librato.connect('email', 'token')
 # Submit when the 400th metric is queued
 q = api.new_queue(auto_submit_count=400)
-```
-
-## Submitting tagged measurements
-
-NOTE: **Tagged measurements are only available in the Tags Beta. Please [contact Librato support](mailto:support@librato.com) to join the beta.**
-
-We can use tags in the submit method in order to associate key value pairs with our
-measurements:
-
-```python
-    api.submit("temperature", 22, tags={'city': 'austin', 'station': '27'})
-```
-
-Queues also support tags. When adding measurements to a queue, we can associate tags to them
-in the same way we do with the submit method:
-
-```python
-    q = api.new_queue()
-    q.add('temperature', 12, tags={'city': 'sf'      , 'station': '12'})
-    q.add('temperature', 14, tags={'city': 'new york', 'station': '1'})
-    q.add('temperature', 22, tags={'city': 'austin'  , 'station': '112'})
-    q.submit()
 ```
 
 ## Updating Metric Attributes
@@ -210,11 +175,9 @@ You can update the information for a metric by using the `update` method,
 for example:
 
 ```python
-api = librato.connect('email', 'token')
-for metric in api.list_metrics(name=" "):
-  gauge = api.get(metric.name)
-  attrs = gauge.attributes
-  attrs['display_units_long'] = 'ms'
+for metric in api.list_metrics(name="abc*"):
+  attrs = metric.attributes
+  attrs['display_units_short'] = 'ms'
   api.update(metric.name, attributes=attrs)
 ```
 
@@ -298,67 +261,8 @@ space.delete()
 ```
 
 ### Create a Chart
-```python
-# Create a Chart directly via API (defaults to line chart)
-space = api.find_space('Production')
-chart = api.create_chart(
-    'cpu',
-    space,
-    streams=[{'metric': 'cpu.idle', 'source': '*'}]
-)
-```
 
-```python
-# Create line chart using the Space model
-space = api.find_space('Production')
-
-# You can actually create an empty chart (default to line)
-chart = space.add_chart('cpu')
-
-# Create a chart with all attributes
-chart = space.add_chart(
-    'memory',
-    type='line',
-    streams=[
-      {'metric': 'memory.free', 'source': '*'},
-      {'metric': 'memory.used', 'source': '*',
-        'group_function': 'breakout', 'summary_function': 'average'}
-    ],
-    min=0,
-    max=50,
-    label='the y axis label',
-    use_log_yaxis=True,
-    related_space=1234
-)
-```
-
-```python
-# Shortcut to create a line chart with a single metric on it
-chart = space.add_single_line_chart('my chart', 'my.metric', '*')
-chart = space.add_single_line_chart('my chart', metric='my.metric', source='*')
-```
-
-```python
-# Shortcut to create a stacked chart with a single metric on it
-chart = space.add_single_stacked_chart('my chart', 'my.metric', '*')
-```
-
-```python
-# Create a big number chart
-bn = space.add_chart(
-    'memory',
-    type='bignumber',
-    streams=[{'metric': 'my.metric', 'source': '*'}]
-)
-# Shortcut to add big number chart
-bn = space.add_bignumber_chart('My Chart', 'my.metric', '*')
-bn = space.add_bignumber_chart('My Chart', 'my.metric',
-  source='*',
-  group_function='sum',
-  summary_function='sum',
-  use_last_value=True
-)
-```
+Not yet supported for tags-based accounts.
 
 ### Find a Chart
 ```python
@@ -368,12 +272,8 @@ chart = api.get_chart(chart_id, space)
 ```
 
 ### Update a Chart
-```python
-chart = api.get_chart(chart_id, space_id)
-chart.min = 0
-chart.max = 50
-chart.save()
-```
+
+Not yet supported for tags-based accounts.
 
 ### Rename a Chart
 ```python
@@ -382,21 +282,11 @@ chart = api.get_chart(chart_id, space_id)
 chart.rename('new chart name')
 ```
 
-### Add new metrics to a Chart
-```python
-chart = space.charts()[-1]
-chart.new_stream('foo', '*')
-chart.new_stream(metric='foo', source='*')
-chart.new_stream(composite='s("foo", "*")')
-chart.save()
-```
-
 ### Delete a Chart
 ```python
 chart = api.get_chart(chart_id, space_id)
 chart.delete()
 ```
-
 
 ## Alerts
 
@@ -473,53 +363,6 @@ print(alert.conditions)
 print(alert.services)
 ```
 
-
-## Client-side Aggregation
-
-You can aggregate measurements before submission using the `Aggregator` class.  Optionally, specify a `measure_time` to submit that timestamp to the API.  You may also optionally specify a `period` to floor the timestamp to a particular interval.  If `period` is specified without a `measure_time`, the current timestamp will be used, and floored to `period`.  Specifying an optional `source` allows the aggregated measurement to report a source name.
-
-Aggregator instances can be sent immediately by calling `submit()` or added to a `Queue` by calling `queue.add_aggregator()`.
-
-```python
-from librato.aggregator import Aggregator
-
-api = librato.connect('email', 'token')
-
-a = Aggregator(api)
-a.add("foo", 42)
-a.add("foo", 5)
-# count=2, min=5, max=42, sum=47 (value calculated by API = mean = 23.5), source=unassigned
-# measure_time = <now>
-a.submit()
-
-a = Aggregator(api, source='my.source', period=60)
-a.add("foo", 42)
-a.add("foo", 5)
-# count=2, min=5, max=42, sum=47 (value calculated by API = mean = 23.5), source=my.source
-# measure_time = <now> - (<now> % 60)
-a.submit()
-
-a = Aggregator(api, period=60, measure_time=1419302671)
-a.add("foo", 42)
-a.add("foo", 5)
-# count=2, min=5, max=42, sum=47 (value calculated by API = mean = 23.5), source=unassigned
-# measure_time = 1419302671 - (1419302671 % 60) = 1419302671 - 31 = 1419302640
-a.submit()
-
-a = Aggregator(api, measure_time=1419302671)
-a.add("foo", 42)
-a.add("foo", 5)
-# count=2, min=5, max=42, sum=47 (value calculated by API = mean = 23.5), source=unassigned
-# measure_time = 1419302671
-a.submit()
-
-
-# You can also add an Aggregator instance to a queue
-q = librato.queue.Queue(api)
-q.add_aggregator(a)
-q.submit()
-```
-
 ## Misc
 
 ### Timeouts
@@ -529,8 +372,8 @@ that by using `api.set_timeout(timeout)`.
 
 ## Contribution
 
-Do you want to contribute? Do you need a new feature? Please open a
-[ticket](https://github.com/librato/python-librato/issues).
+Want to contribute? Need a new feature? Please open an
+[issue](https://github.com/librato/python-librato/issues).
 
 ## Contributors
 
@@ -539,4 +382,4 @@ graciously handed over maintainership of the project to us and we're super-appre
 
 ## Copyright
 
-Copyright (c) 2011-2016 [Librato Inc.](http://librato.com) See LICENSE for details.
+Copyright (c) 2011-2017 [Librato Inc.](http://librato.com) See LICENSE for details.

--- a/librato/metrics.py
+++ b/librato/metrics.py
@@ -47,10 +47,14 @@ class Metric(object):
     def from_dict(cls, connection, data):
         """Returns a metric object from a dictionary item,
         which is usually from librato's API"""
-        if data.get('type') == "gauge":
+        metric_type = data.get('type')
+        if metric_type == "gauge":
             cls = Gauge
-        elif data.get('type') == "counter":
+        elif metric_type == "counter":
             cls = Counter
+        elif metric_type == "composite":
+            # Since we don't have a formal Composite class, use Gauge for now
+            cls = Gauge
 
         obj = cls(connection, data['name'])
         obj.period = data['period']
@@ -58,7 +62,8 @@ class Metric(object):
         obj.description = data['description'] if 'description' in data else None
         obj.measurements = data['measurements'] if 'measurements' in data else {}
         obj.query = data['query'] if 'query' in data else {}
-        obj.composite = data['composite'] if 'composite' in data else None
+        obj.composite = data.get('composite', None)
+        obj.source_lag = data.get('source_lag', None)
 
         return obj
 


### PR DESCRIPTION
- [x] Update examples to use `tags` instead of `source`
- [x] Add a `get_measurements()` method to wrap `get_tagged()`
- [x] Add a temporary `get_composite_tagged()` method because we can't break the existing `get_composite()` method.
- [x] Allow composites to be returned from `list_metrics()`
- [x] Remove unsupported `Aggregator` from docs.
- [x] Remove unsupported `Chart` operations from docs.
- [x] Remove unsupported Alert `add_condition_for` operation from docs.
- [x] Update top of README to point to legacy readme.