### PR TITLE
Don't ellide metric when composite key present on a Stream

### DIFF
--- a/librato/streams.py
+++ b/librato/streams.py
@@ -38,11 +38,6 @@ class Stream(object):
         for attr in kwargs:
             setattr(self, attr, kwargs[attr])
 
-        # Can't have a composite and source/metric
-        if self.composite:
-            self.source = None
-            self.metric = None
-
     def _attrs(self):
         return ['metric', 'source', 'composite', 'name',
                 'type', 'id', 'group_function', 'summary_function', 'transform_function', 'downsample_function',

--- a/librato/streams.py
+++ b/librato/streams.py
@@ -38,6 +38,10 @@ class Stream(object):
         for attr in kwargs:
             setattr(self, attr, kwargs[attr])
 
+        # Can't have a composite and source
+        if self.composite:
+            self.source = None
+
     def _attrs(self):
         return ['metric', 'source', 'composite', 'name',
                 'type', 'id', 'group_function', 'summary_function', 'transform_function', 'downsample_function',


### PR DESCRIPTION
If I create a new chart via this SDK with `metric` set to "some.composite.metric", where "some.composite.metric" is a _composite_ metric already defined in AppOptics with the function, `sum("another.metric)"`, then later request this chart's definition via the `/metrics-api/v1/sdk_charts/...` API, the stream's JSON will include _both_ the `metric` key I defined above _and_ a `composite` key including the function defined for that composite metric. e.g.:

```
GET /metrics-api/v1/sdk_charts/9999
...
"streams:[
  "0":{
    "composite": "sum(\"another.metric)\"",
    ...
    "metric": "some.composite.metric",
...
```

There's some code in streams.py -- removed in this PR -- that deletes the `metric` key if `composite` is present. It seems that this may not be the best behavior for composite metrics, as `metric` contains important information about the stream that can't be found elsewhere.

(I found this while working on a script that checks the _current_ chart definition against the _desired_ chart definition in order to decide whether or not the chart needed to be re-created)